### PR TITLE
TextField: remove redundant field layer [+]

### DIFF
--- a/src/lib/TextField.js
+++ b/src/lib/TextField.js
@@ -1,6 +1,6 @@
 // This file is part of React-Invenio-Forms
-// Copyright (C) 2020 CERN.
-// Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
 //
 // React-Invenio-Forms is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -10,23 +10,20 @@ import PropTypes from 'prop-types';
 import { FastField, Field, getIn } from 'formik';
 import { Form } from 'semantic-ui-react';
 
-import { ErrorLabel } from './ErrorLabel';
 
 export class TextField extends Component {
   renderFormField = (formikBag) => {
-    const { fieldPath, optimized, ...uiProps } = this.props;
+    const { fieldPath, optimized, error, ...uiProps } = this.props;
     return (
-      <Form.Field id={fieldPath}>
-        <Form.Input
+      <Form.Input
           id={fieldPath}
           name={fieldPath}
           onChange={formikBag.form.handleChange}
           onBlur={formikBag.form.handleBlur}
           value={getIn(formikBag.form.values, fieldPath, '')}
+          error={error || getIn(formikBag.form.errors, fieldPath, null)}
           {...uiProps}
-        ></Form.Input>
-        <ErrorLabel fieldPath={fieldPath} />
-      </Form.Field>
+      />
     );
   };
 


### PR DESCRIPTION
Turns out that the TextField had 2 layers of `<div class='field'>`
which interfered with layout in forms. Removing it allows us
to place the TextField correctly and get array rows to fill out
the length of the row.

I had to remove ErrorLabel from TextField to achieve this, but the
error props seems enough. I have attached screenshots to show it.

![title_error](https://user-images.githubusercontent.com/1932651/105763117-ffc7ba80-5f1a-11eb-99ce-9ad5ef3397ad.png)

![publication_date_error](https://user-images.githubusercontent.com/1932651/105763116-ff2f2400-5f1a-11eb-8ed1-1f7d1f052391.png)

Needed for https://github.com/inveniosoftware/react-invenio-deposit/issues/171