### PR TITLE
ArrayComponent: add help text + fix button

### DIFF
--- a/src/lib/ArrayField.js
+++ b/src/lib/ArrayField.js
@@ -34,6 +34,7 @@ export class ArrayField extends Component {
       fieldPath,
       label,
       labelIcon,
+      helpText,
       ...uiProps
     } = this.props;
 
@@ -63,9 +64,12 @@ export class ArrayField extends Component {
           );
         })}
 
+        <label className="helptext">
+          {helpText}
+        </label>
+
         <Form.Group>
           <Form.Button
-            icon
             type="button"
             onClick={() => arrayHelpers.push(defaultNewValue)}
           >
@@ -93,12 +97,14 @@ ArrayField.propTypes = {
   defaultNewValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     .isRequired,
   fieldPath: PropTypes.string.isRequired,
+  helpText: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   labelIcon: PropTypes.string,
 };
 
 ArrayField.defaultProps = {
-  label: '',
   addButtonLabel: 'Add new row',
+  helpText: '',
+  label: '',
   placeholder: '',
 };


### PR DESCRIPTION
- the button fix is because buttons that expect **only** an icon should have `icon`, but that's not the case for the array add button. 
- required for https://github.com/inveniosoftware/react-invenio-deposit/issues/171 