### PR TITLE
RemoteSelectField: use 'suggest' instead of 'q'

### DIFF
--- a/src/lib/RemoteSelectField.js
+++ b/src/lib/RemoteSelectField.js
@@ -123,7 +123,7 @@ export class RemoteSelectField extends Component {
     return axios
       .get(suggestionAPIUrl, {
         params: {
-          q: searchQuery,
+          suggest: searchQuery,
           size: DEFAULT_SUGGESTION_SIZE,
           ...suggestionAPIQueryParams,
         },


### PR DESCRIPTION
partially closes inveniosoftware/invenio-app-rdm#738