### PR TITLE
dependencies: bump axios peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-forms",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "formik": "^2.1.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-forms",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "React components to build forms in Invenio",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",


### PR DESCRIPTION
- part of closing inveniosoftware/invenio-app-rdm#956
  to be compatible with inveniosoftware/invenio-search-ui#122
- dependencies: bump axios peer dependency
- release: v0.8.5
