### PR TITLE
richinputfield: make it require-able error-able [+]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+Version 0.8.6 (released 2021-07-20)
+* Improve RichInputField (error-able, require-able)
+
+Version 0.8.5 (released 2021-07-19)
+* Security bump of peerDependency axios to 0.21.1
+
 Version 0.8.4 (released 2021-07-09)
 * Expose added value serialization in the RemoteSelectField
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-forms",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-forms",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "React components to build forms in Invenio",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",

--- a/src/lib/RichInputField.js
+++ b/src/lib/RichInputField.js
@@ -15,11 +15,12 @@ import { ErrorLabel, FieldLabel } from 'react-invenio-forms';
 
 export class RichInputField extends Component {
   renderFormField = (formikBag) => {
-    const { fieldPath, label, editorConfig } = this.props;
+    const { editorConfig, fieldPath, label, required } = this.props;
     const value = getIn(formikBag.form.values, fieldPath, '');
+    const error = getIn(formikBag.form.errors, fieldPath, false);
     return (
-      <Form.Field id={fieldPath}>
-        {<FieldLabel htmlFor={fieldPath} label={label}></FieldLabel>}
+      <Form.Field id={fieldPath} required={required} error={error}>
+        {React.isValidElement(label) ? label : <label htmlFor={fieldPath}>{label}</label>}
         <CKEditor
           editor={ClassicEditor}
           config={editorConfig}


### PR DESCRIPTION
- Also detect if label is just text or component, so no extraneous
  wrapping + label becomes red if error when text OR component is passed.
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/966 in part