### PR TITLE
RemoteSelectField: Adds paramsSerializer to axios to encode brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "lodash": "^4.17.15",
+    "query-string": "^7.0.1",
     "semantic-ui-react": "^0.88.0",
     "semantic-ui-css": "^2.4.1",
     "@babel/runtime": "^7.9.0",

--- a/src/lib/RemoteSelectField.js
+++ b/src/lib/RemoteSelectField.js
@@ -144,7 +144,7 @@ export class RemoteSelectField extends Component {
         // remove the paramsSerializer when fixed.
         // https://github.com/axios/axios/issues/3316
         paramsSerializer: (params) => {
-          return queryString.stringify(params, { arrayFormat: 'brackets' });
+          return queryString.stringify(params, { arrayFormat: 'repeat' });
         },
       })
       .then((resp) => resp?.data?.hits?.hits);

--- a/src/lib/RemoteSelectField.js
+++ b/src/lib/RemoteSelectField.js
@@ -12,6 +12,7 @@ import _uniqBy from 'lodash/uniqBy';
 import axios from 'axios';
 import { Message } from 'semantic-ui-react';
 import { SelectField } from './SelectField';
+import queryString from 'query-string';
 
 const DEFAULT_SUGGESTION_SIZE = 20;
 
@@ -139,6 +140,12 @@ export class RemoteSelectField extends Component {
           ...suggestionAPIQueryParams,
         },
         headers: suggestionAPIHeaders,
+        // There is a bug in axios that prevents brackets from being encoded, 
+        // remove the paramsSerializer when fixed.
+        // https://github.com/axios/axios/issues/3316
+        paramsSerializer: (params) => {
+          return queryString.stringify(params, { arrayFormat: 'brackets' });
+        },
       })
       .then((resp) => resp?.data?.hits?.hits);
   };


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-rdm-records/issues/810

TEMPORARY SOLUTION: To be removed when this [(axios) issue](https://github.com/axios/axios/issues/3316) is fixed.

![image](https://user-images.githubusercontent.com/15194802/134694558-70d10306-849d-4f43-8fa1-1602a9398eb2.png)
