### PR TITLE
1146 arrayfield item deletion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+Version 0.9.2 (released 2022-01-13)
+* ArrayField: Use injected `__key` as stable array item key.
+
 Version 0.9.1 (released 2021-12-03)
 * Pass the `search` property down to RemoteSelectField
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-forms",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-forms",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "React components to build forms in Invenio",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",

--- a/src/lib/ArrayField.js
+++ b/src/lib/ArrayField.js
@@ -1,6 +1,6 @@
 // This file is part of React-Invenio-Forms
 // Copyright (C) 2020-2021 CERN.
-// Copyright (C) 2020-2021 Northwestern University.
+// Copyright (C) 2020-2022 Northwestern University.
 //
 // React-Invenio-Forms is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -13,6 +13,14 @@ import { Form, Icon } from 'semantic-ui-react';
 import { FieldLabel } from './FieldLabel';
 
 export class ArrayField extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      // Chosen because it will never cross with 0-indexed pre-existing keys.
+      nextKey: -1,
+    };
+  }
+
   hasGroupErrors = (errors) => {
     for (const field in errors) {
       if (field.startsWith(this.props.fieldPath)) {
@@ -46,10 +54,7 @@ export class ArrayField extends Component {
         {getIn(values, fieldPath, []).map((value, index, array) => {
           const arrayPath = fieldPath;
           const indexPath = index;
-          const key = `${arrayPath}.${indexPath}`;
-          // TODO: Revise what we pass to children to have a nice interface
-          // Passing: array, arrayHelpers, parentFieldPath, index and ...props
-          //          seems enough.
+          const key = value.__key || index;
           return (
             <div key={key}>
               {children({
@@ -69,7 +74,13 @@ export class ArrayField extends Component {
         <Form.Group>
           <Form.Button
             type="button"
-            onClick={() => arrayHelpers.push(defaultNewValue)}
+            onClick={() => {
+              arrayHelpers.push({
+                ...defaultNewValue,
+                __key: this.state.nextKey
+              });
+              this.setState((state) => ({ nextKey: state.nextKey - 1 }));
+            }}
           >
             <Icon name="add" />
             {addButtonLabel}


### PR DESCRIPTION
- part of closing inveniosoftware/invenio-app-rdm#1146
- ArrayField: use a stable key for items:

This is a bit of a tricky one. Issue inveniosoftware/invenio-app-rdm#1146
summarizes the observed problem. The source of it was in bad interaction
between TextField, formik and list of React components. tldr; we didn't use
stable keys.

In order to keep the benefits of TextField's optimizations, I fixed the
key problem (see https://reactjs.org/docs/lists-and-keys.html#keys) by
generating artificial keys in react-invenio-deposit's deserialization
of concerned fields and by making any new item in the array
be injected with a key that will never cross those artificially generated
ones in react-invenio-deposit. This ends up giving us stable keys which in
turn makes our React list behave correctly.

This is even stable across Saves/updates which is nice.

- release: v0.9.2


(assigning it to React afficionados)