### PR TITLE
elements: add responsive sidebar

### DIFF
--- a/src/lib/elements/GridResponsiveSidebarColumn.js
+++ b/src/lib/elements/GridResponsiveSidebarColumn.js
@@ -1,0 +1,53 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Grid, Sidebar, Button, Segment } from "semantic-ui-react";
+
+export class GridResponsiveSidebarColumn extends React.Component {
+  render() {
+    const closeSidebarBtnRef = React.createRef();
+    const { width, open, onHideClick, children } = this.props;
+
+    return (
+      <>
+        <Grid.Column width={width} only="mobile tablet">
+          <Sidebar
+            as={Segment}
+            animation="overlay"
+            visible={open}
+            width="wide"
+            onHide={onHideClick}
+            onShow={() => closeSidebarBtnRef.current.focus()}
+          >
+            <Button
+              basic
+              icon="close"
+              size="small"
+              floated="right"
+              onClick={onHideClick}
+              aria-label="Close filter"
+              ref={closeSidebarBtnRef}
+              className="mb-20"
+            />
+
+            {children}
+          </Sidebar>
+        </Grid.Column>
+
+        <Grid.Column width={width} only="computer">
+          {children}
+        </Grid.Column>
+      </>
+    );
+  }
+}
+
+GridResponsiveSidebarColumn.propTypes = {
+  width: PropTypes.number,
+  open: PropTypes.bool.isRequired,
+  onHideClick: PropTypes.func.isRequired,
+  children: PropTypes.any.isRequired,
+};
+
+GridResponsiveSidebarColumn.defaultProps = {
+  width: 4,
+};

--- a/src/lib/elements/index.js
+++ b/src/lib/elements/index.js
@@ -9,3 +9,4 @@
  */
 export { Image } from "./Image";
 export { withCancel } from "./withCancel";
+export { GridResponsiveSidebarColumn } from "./GridResponsiveSidebarColumn";


### PR DESCRIPTION
- Added responsive sidebar component that can be opened or closed on mobile/tablet.
- Sidebar closes on mobile/tablet when clicking the close-button and/or outside the sidebar.
- On desktop, the sidebar is always visible.

## Screenshots

__Tablet__
<img width="884" alt="Screenshot 2022-03-10 at 10 11 41" src="https://user-images.githubusercontent.com/21052053/158995933-445d6ca2-69f0-4f3c-9779-f0ce69f1d106.png">

__Mobile__
<img width="468" alt="Screenshot 2022-03-10 at 10 12 16" src="https://user-images.githubusercontent.com/21052053/158995942-8b9955a7-49cf-41d5-ab1a-f5ebde72614b.png">

