### PR TITLE
text-field: hide helptext label if no content

### DIFF
--- a/src/lib/forms/TextField.js
+++ b/src/lib/forms/TextField.js
@@ -62,7 +62,7 @@ export class TextField extends Component {
           }
           {...uiProps}
         />
-        <label className="helptext">{helpText}</label>
+        {helpText && <label className="helptext">{helpText}</label>}
       </>
     );
   };


### PR DESCRIPTION
Hides label if there is no label-content. To avoid extra spacing in the layout.