### PR TITLE
responsive sidebar: remove default width value

### DIFF
--- a/src/lib/elements/GridResponsiveSidebarColumn.js
+++ b/src/lib/elements/GridResponsiveSidebarColumn.js
@@ -70,7 +70,7 @@ GridResponsiveSidebarColumn.propTypes = {
 };
 
 GridResponsiveSidebarColumn.defaultProps = {
-  width: 4,
+  width: undefined,
   mobile: undefined,
   tablet: undefined,
   computer: undefined,


### PR DESCRIPTION
The `GridResponsiveSidebarColumn` component is causing a lot of errors in the console due to conflicting width values. 
![Screenshot 2022-08-18 at 10 50 43](https://user-images.githubusercontent.com/21052053/185355551-36e23db0-385a-4f06-8c9d-6eff0361fc63.png)


We have defined a default `width` value which is conflicting when we use the responsive width props instead (`mobile`, `tablet`, `computer`, ...).

This PR sets the default value to `undefined`.