### PR TITLE
Add multi input

### DIFF
--- a/src/lib/forms/widgets/text/MultiInput.js
+++ b/src/lib/forms/widgets/text/MultiInput.js
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { useFormikContext, getIn } from "formik";
+
+import { FieldLabel } from "../../FieldLabel";
+import { SelectField } from "../../SelectField";
+
+export default function MultiInput({
+  additionLabel,
+  description,
+  placeholder,
+  fieldPath,
+  label,
+  icon,
+  required,
+}) {
+  const [options, setOptions] = useState([]);
+  const { values } = useFormikContext();
+  const serializeValues = (values) =>
+    values?.map((item) => ({
+      text: item,
+      key: item,
+      value: item,
+    }));
+
+  return (
+    <>
+      <SelectField
+        fieldPath={fieldPath}
+        label={<FieldLabel htmlFor={fieldPath} icon={icon} label={label} />}
+        options={serializeValues(getIn(values, fieldPath, []))}
+        placeholder={placeholder}
+        required={required}
+        search
+        multiple
+        clearable
+        optimized
+        defaultValue={[]}
+        noResultsMessage={null} // hide the no results message
+        additionLabel={additionLabel}
+        onChange={({ data, formikProps }) => {
+          setOptions(serializeValues(data.value));
+          formikProps.form.setFieldValue(fieldPath, data.value);
+        }}
+        allowAdditions
+        onAddItem={({ data }) => {
+          setOptions([{ text: data.value, value: data.value }, ...options]);
+        }}
+      />
+      {description && <label className="helptext">{description}</label>}
+    </>
+  );
+}
+
+MultiInput.propTypes = {
+  fieldPath: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  additionLabel: PropTypes.string,
+  icon: PropTypes.string,
+  required: PropTypes.bool,
+};
+
+MultiInput.defaultProps = {
+  additionLabel: undefined,
+  icon: undefined,
+  required: false,
+};

--- a/src/lib/forms/widgets/text/index.js
+++ b/src/lib/forms/widgets/text/index.js
@@ -1,3 +1,4 @@
 export { default as RichInput } from "./RichInput";
 export { default as TextArea } from "./TextArea";
 export { default as Input } from "./Input";
+export { default as MultiInput } from "./MultiInput";


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1872
Adding `MultiInput` widget. A user can use this widget to insert a list of text values.

# Screenshots
![Screenshot 2022-09-14 at 17 42 48](https://user-images.githubusercontent.com/22594783/190200868-2505edb7-53b9-49cf-895d-82c83f926008.png)
![Screenshot 2022-09-14 at 17 43 09](https://user-images.githubusercontent.com/22594783/190200872-9fa31503-b73b-4f62-8610-974c77860d4d.png)
