### PR TITLE
array field: show empty value only once

### DIFF
--- a/src/lib/forms/ArrayField.js
+++ b/src/lib/forms/ArrayField.js
@@ -20,6 +20,7 @@ export class ArrayField extends Component {
     this.state = {
       // Chosen because it will never cross with 0-indexed pre-existing keys.
       nextKey: -1,
+      hasBeenShown: false,
     };
   }
 
@@ -41,10 +42,17 @@ export class ArrayField extends Component {
    */
   getValues = (values, fieldPath) => {
     const { requiredOptions, defaultNewValue, showEmptyValue } = this.props;
+    const { hasBeenShown } = this.state;
     const existingValues = getIn(values, fieldPath, []);
 
-    if (_isEmpty(requiredOptions) && _isEmpty(existingValues) && showEmptyValue) {
+    if (
+      !hasBeenShown &&
+      _isEmpty(requiredOptions) &&
+      _isEmpty(existingValues) &&
+      showEmptyValue
+    ) {
       existingValues.push({ __key: existingValues.length, ...defaultNewValue });
+      this.setState({ hasBeenShown: true });
     }
 
     for (const requiredOption of requiredOptions) {


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2028

https://user-images.githubusercontent.com/6756943/214078633-6962f1d8-d7d1-4baf-828b-5633d9ec42eb.mov

This leas down to several important questions:

- Could we simply fall back to "If it is mandatory we always `showEmptyValue`" and we don't in the opposite case?
- Adding this "hasBeenShown", now opens the door to "enableHasBeenShown". What if the user actually wants to have it always displayed at least once?

This could derivate in an infinite loop of conditions, it should be discussed where to limit it

Thanks @jrcastro2  for the help!
