### PR TITLE
widgets: add rows props to TextArea component

### DIFF
--- a/src/lib/forms/widgets/text/TextArea.js
+++ b/src/lib/forms/widgets/text/TextArea.js
@@ -6,7 +6,7 @@ import { TextAreaField } from "../../TextAreaField";
 
 export default class TextArea extends Component {
   render() {
-    const { fieldPath, required, label, icon, description } = this.props;
+    const { fieldPath, required, label, icon, description, rows } = this.props;
 
     return (
       <>
@@ -15,6 +15,7 @@ export default class TextArea extends Component {
           fieldPath={fieldPath}
           required={required}
           label={<FieldLabel htmlFor={fieldPath} icon={icon} label={label} />}
+          rows={rows}
         />
         {description && <label className="helptext">{description}</label>}
       </>
@@ -28,9 +29,11 @@ TextArea.propTypes = {
   description: PropTypes.string.isRequired,
   icon: PropTypes.string,
   required: PropTypes.bool,
+  rows: PropTypes.number,
 };
 
 TextArea.defaultProps = {
   icon: undefined,
   required: false,
+  rows: 3,
 };


### PR DESCRIPTION
Before: default semantic-ui rows count 3 used
After: specified amount of rows used (default still 3)

closes https://github.com/inveniosoftware/invenio-banners/issues/10
