### PR TITLE
Fix 'browser' entry in dist/package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "rimraf dist && NODE_ENV=production rollup -c --failAfterWarnings --inlineDynamicImports",
-    "edit-linked-package": "json -I -f ./dist/package.json -e 'this.module=\"esm/index.js\", this.main=\"cjs/index.js\"' ",
+    "edit-linked-package": "json -I -f ./dist/package.json -e 'this.module=\"esm/index.js\", this.main=\"cjs/index.js\", this.browser=\"cjs/index.js\"' ",
     "prelink-dist": "cp package.json ./dist && npm run edit-linked-package",
     "link-dist": "cd dist && npm link",
     "postlink-dist": "cd dist && rm -rf node_modules",


### PR DESCRIPTION
When developing the `react-invenio-forms` module with `invenio-cli assets watch-module --link /path/to/react-invenio-forms`, then the `{pre,post,}link-dist` steps will copy the `package.json` into `dist/` and modify it slightly.
Also, the `dist` directory will be linked: `${venv}/var/instance/assets/node_modules/react-invenio-forms -> /path/to/react-invenio-forms/dist`.

The directory structure should look like the following:
```
assets/node_modules/react-invenio-forms
├── cjs
│   ├── index.js
│   └── index.js.map
├── esm
│   ├── index.js
│   └── index.js.map
└── package.json
```

Without this change, the `package.json` will include the following three entries:
```
  "main": "cjs/index.js",
  "browser": "dist/cjs/index.js",
  "module": "esm/index.js",
```
The `dist/cjs/index.js` doesn't exist however, because we are already _in_ the `dist` directory.