### PR TITLE
ErrorMessage: remove content class wrapper

### DIFF
--- a/src/lib/elements/ErrorMessage.js
+++ b/src/lib/elements/ErrorMessage.js
@@ -51,11 +51,11 @@ export class ErrorMessage extends Component {
     return (
       <Message icon {...uiProps}>
         {icon && <Icon name={icon} />}
-        <Message.Content role="alert">
+        <div role="alert">
           {header && <Message.Header>{header}</Message.Header>}
-          {content}
+          <p>{content}</p>
           {!_isEmpty(errors) && <FieldErrorList fieldErrors={errors} />}
-        </Message.Content>
+        </div>
       </Message>
     );
   }


### PR DESCRIPTION
Removes the white bg box in the error message component (caused by nested `.content` classes).

Before
<img width="889" alt="Screenshot 2023-11-09 at 4 45 54 PM" src="https://github.com/inveniosoftware/react-invenio-forms/assets/21052053/669e416c-cf5f-4114-8510-54b9b3fab07c">


After
<img width="1109" alt="Screenshot 2023-11-09 at 4 47 04 PM" src="https://github.com/inveniosoftware/react-invenio-forms/assets/21052053/111ef623-8ed7-476f-85ec-a1d1713798eb">
