### PR TITLE
ajax: change default accept headers for all ajax calls

### DIFF
--- a/src/lib/api/connector.js
+++ b/src/lib/api/connector.js
@@ -17,7 +17,7 @@ const baseAxiosConfiguration = {
   xsrfCookieName: "csrftoken",
   xsrfHeaderName: "X-CSRFToken",
   headers: {
-    "Accept": "application/json",
+    "Accept": "application/vnd.inveniordm.v1+json",
     "Content-Type": "application/json",
   },
 };


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/598