### PR TITLE
Add DiffTimestamps function

### DIFF
--- a/src/lib/locale/DiffTimestamps.js
+++ b/src/lib/locale/DiffTimestamps.js
@@ -1,0 +1,55 @@
+// This file is part of React-Invenio-Forms
+// Copyright (C) 2024 CERN.
+//
+// React-Invenio-Forms is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { DateTime } from "luxon";
+
+/**
+ * Create duration string for two given timestamps
+ *
+ * @param firstTimestamp string ISO timestamp
+ * @param secondTimestamp string ISO timestamp
+ * @returns {string} string representation of duration, i.e. 3 days
+ */
+export const diffTimestamps = (firstTimestamp, secondTimestamp, language = "en") => {
+  const first = DateTime.fromISO(firstTimestamp);
+  const second = DateTime.fromISO(secondTimestamp);
+  const duration = first.diff(second).reconfigure({ locale: language });
+  // If we used a newer version of luxon we could just do this:
+  // return duration.toHuman();
+
+  // instead return the largest unit and value (ignore everything smaller)
+  const rescale = duration.shiftTo(
+    "years",
+    "months",
+    "weeks",
+    "days",
+    "hours",
+    "minutes",
+    "seconds",
+    "milliseconds"
+  ); // in new luxon this is just duration.rescale()
+  const units = [
+    "years",
+    "months",
+    "weeks",
+    "days",
+    "hours",
+    "minutes",
+    "seconds",
+    "milliseconds",
+  ];
+
+  for (const unit of units) {
+    if (rescale[unit] && rescale[unit] > 0) {
+      if (rescale[unit] == 1) {
+        return rescale[unit] + " " + unit.slice(0, -1); // remove s
+      } else {
+        return rescale[unit] + " " + unit;
+      }
+    }
+  }
+  return "-"; // in case all components are zero
+};

--- a/src/lib/locale/index.js
+++ b/src/lib/locale/index.js
@@ -1,1 +1,2 @@
 export { toRelativeTime } from "./RelativeTime";
+export { diffTimestamps } from "./DiffTimestamps";


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

At the moment we have `toRelativeTime` which produces a string like "in 2 minutes" or "2 minutes ago" from one timestamp.

In this PR I introduce `diffTimestamps` which produces a string like "2 minutes" from two time stamps.

Unfortunately I have had to write my own version of this as we are using an old version of Luxon. I'm not sure how much hassle it would be to upgrade Luxon.

![image](https://github.com/inveniosoftware/react-invenio-forms/assets/6676843/579524a7-c509-4991-b5ac-b6b7b5200229)


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
