### PR TITLE
RemoteSelect: pass searchQueryParamName as a property

### DIFF
--- a/src/lib/forms/RemoteSelectField.js
+++ b/src/lib/forms/RemoteSelectField.js
@@ -103,13 +103,17 @@ export class RemoteSelectField extends Component {
   }, this.props.debounceTime);
 
   fetchSuggestions = async (searchQuery) => {
-    const { suggestionAPIUrl, suggestionAPIQueryParams, suggestionAPIHeaders } =
-      this.props;
+    const {
+      suggestionAPIUrl,
+      suggestionAPIQueryParams,
+      suggestionAPIHeaders,
+      searchQueryParamName,
+    } = this.props;
 
     try {
       const response = await axios.get(suggestionAPIUrl, {
         params: {
-          suggest: searchQuery,
+          [searchQueryParamName]: searchQuery,
           size: DEFAULT_SUGGESTION_SIZE,
           ...suggestionAPIQueryParams,
         },
@@ -172,6 +176,7 @@ export class RemoteSelectField extends Component {
       serializeAddedValue,
       suggestionAPIHeaders,
       debounceTime,
+      searchQueryParamName,
       noResultsMessage,
       loadingMessage,
       suggestionsErrorMessage,
@@ -191,6 +196,7 @@ export class RemoteSelectField extends Component {
       serializeSuggestions,
       serializeAddedValue,
       debounceTime,
+      searchQueryParamName,
       noResultsMessage,
       loadingMessage,
       suggestionsErrorMessage,
@@ -270,6 +276,7 @@ RemoteSelectField.propTypes = {
   loadingMessage: PropTypes.string,
   suggestionsErrorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   noQueryMessage: PropTypes.string,
+  searchQueryParamName: PropTypes.string,
   preSearchChange: PropTypes.func, // Takes a string and returns a string
   onValueChange: PropTypes.func, // Takes the SUI hanf and updated selectedSuggestions
   search: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
@@ -282,6 +289,7 @@ RemoteSelectField.defaultProps = {
   suggestionAPIQueryParams: {},
   suggestionAPIHeaders: {},
   serializeSuggestions: serializeSuggestions,
+  searchQueryParamName: "suggest",
   suggestionsErrorMessage: "Something went wrong...",
   noQueryMessage: "Search...",
   noResultsMessage: "No results found.",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

The remote select field assumes that we always want to pass the `searchQuery` with `?suggest=[searchQuery]`. Often we want to instead use `q=[searchQuery]` or similar. This PR allows us to customise the name of the parameter using props

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
