### PR TITLE
search: allowing search param key to be modified

### DIFF
--- a/src/lib/forms/RemoteSelectField.js
+++ b/src/lib/forms/RemoteSelectField.js
@@ -103,13 +103,17 @@ export class RemoteSelectField extends Component {
   }, this.props.debounceTime);
 
   fetchSuggestions = async (searchQuery) => {
-    const { suggestionAPIUrl, suggestionAPIQueryParams, suggestionAPIHeaders } =
-      this.props;
+    const {
+      suggestionAPIUrl,
+      suggestionAPIQueryParams,
+      suggestionAPIHeaders,
+      searchParamKey,
+    } = this.props;
 
     try {
       const response = await axios.get(suggestionAPIUrl, {
         params: {
-          suggest: searchQuery,
+          [searchParamKey]: searchQuery,
           size: DEFAULT_SUGGESTION_SIZE,
           ...suggestionAPIQueryParams,
         },
@@ -259,6 +263,7 @@ RemoteSelectField.propTypes = {
   suggestionAPIUrl: PropTypes.string.isRequired,
   suggestionAPIQueryParams: PropTypes.object,
   suggestionAPIHeaders: PropTypes.object,
+  searchParamKey: PropTypes.string,
   serializeSuggestions: PropTypes.func,
   serializeAddedValue: PropTypes.func,
   initialSuggestions: PropTypes.oneOfType([
@@ -281,6 +286,7 @@ RemoteSelectField.defaultProps = {
   debounceTime: 500,
   suggestionAPIQueryParams: {},
   suggestionAPIHeaders: {},
+  searchParamKey: "suggest",
   serializeSuggestions: serializeSuggestions,
   suggestionsErrorMessage: "Something went wrong...",
   noQueryMessage: "Search...",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Related to https://github.com/zenodo/zenodo-rdm/issues/890

Makes the searchParamKey configurable to make it more accurate, previously it was set to `suggest`, which did not work well for certain endpoints e.g. `api/awards`

`https://127.0.0.1:5000/api/awards?q=micro` - _returns **10** records containing the word micro in title_
whereas, `https://127.0.0.1:5000/api/awards?suggest=micro` - _returns **0** records_
this would cause problems when users are searching for relevant results

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
