### PR TITLE
Editor: Fix Jumping Cursor

### DIFF
--- a/src/lib/forms/RichEditor.js
+++ b/src/lib/forms/RichEditor.js
@@ -1,6 +1,7 @@
 // This file is part of React-Invenio-Forms
 // Copyright (C) 2022 CERN.
 // Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2024 KTH Royal Institute of Technology.
 //
 // React-Invenio-Forms is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -19,8 +20,18 @@ import PropTypes from "prop-types";
 
 export class RichEditor extends Component {
   render() {
-    const { id, value, disabled, minHeight, onBlur, onChange, onFocus, editorConfig } =
-      this.props;
+    const {
+      id,
+      initialValue,
+      disabled,
+      minHeight,
+      onBlur,
+      onChange,
+      onFocus,
+      editorConfig,
+      inputValue,
+      onEditorChange,
+    } = this.props;
     const config = {
       branding: false,
       menubar: false,
@@ -39,23 +50,27 @@ export class RichEditor extends Component {
 
     return (
       <Editor
-        initialValue={value}
+        initialValue={initialValue}
+        value={inputValue}
         init={config}
         id={id}
         disabled={disabled}
-        onChange={onChange}
         onBlur={onBlur}
         onFocus={onFocus}
+        onChange={onChange}
+        onEditorChange={onEditorChange}
       />
     );
   }
 }
 
 RichEditor.propTypes = {
-  value: PropTypes.string,
+  initialValue: PropTypes.string,
+  inputValue: PropTypes.string,
   id: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
+  onEditorChange: PropTypes.func,
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
   minHeight: PropTypes.number,
@@ -64,10 +79,12 @@ RichEditor.propTypes = {
 
 RichEditor.defaultProps = {
   minHeight: 250,
-  value: "",
+  initialValue: "",
+  inputValue: "",
   id: undefined,
   disabled: undefined,
   onChange: undefined,
+  onEditorChange: undefined,
   onBlur: undefined,
   onFocus: undefined,
   editorConfig: undefined,


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2730
* See https://www.tiny.cloud/docs/tinymce/6/react-ref/#initialvalue
* Add the missing `onEditorChange` and `initialValue` props.
* There was ambiguity between `value` and `initialValue` in the props consumption; this change also fixes that.
* I intentionally kept the prop `value={inputValue}` as `value={value}` seems to conflict with the requests package. 



![cursor-test-1](https://github.com/inveniosoftware/invenio-requests/assets/36583694/23116d28-6c79-49c3-9dc8-8ea74b24be0a)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
