### PR TITLE
editor: Add word count plugin to RichEditor toolbar

### DIFF
--- a/src/lib/forms/RichEditor.js
+++ b/src/lib/forms/RichEditor.js
@@ -15,6 +15,7 @@ import "tinymce/plugins/autoresize";
 import "tinymce/plugins/codesample";
 import "tinymce/plugins/link";
 import "tinymce/plugins/lists";
+import "tinymce/plugins/wordcount";
 import PropTypes from "prop-types";
 
 export class RichEditor extends Component {
@@ -27,10 +28,10 @@ export class RichEditor extends Component {
       statusbar: false,
       min_height: minHeight,
       content_style: "body { font-size: 14px; }",
-      plugins: ["codesample", "link", "lists", "table", "autoresize"],
+      plugins: ["codesample", "link", "lists", "table", "autoresize", "wordcount"],
       contextmenu: false,
       toolbar:
-        "blocks | bold italic link codesample blockquote table | bullist numlist | outdent indent | undo redo",
+        "blocks | bold italic link codesample blockquote table | bullist numlist | outdent indent | wordcount | undo redo",
       autoresize_bottom_margin: 20,
       block_formats: "Paragraph=p; Header 1=h1; Header 2=h2; Header 3=h3",
       table_advtab: false,


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* This is useful when the input field has a character count limit, allowing users to see the current character count.
* Related to https://github.com/inveniosoftware/invenio-requests/pull/391
* Partially closes: https://github.com/inveniosoftware/invenio-app-rdm/issues/2731

![word-count](https://github.com/inveniosoftware/react-invenio-forms/assets/36583694/dbbd4c74-2dde-492f-aef0-f0f91b065b67)


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
