### PR TITLE
Editor: Update RichInputField to use inputValue instead of value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+Version 3.5.2 (released 2024-08-02)
+
+- editor: avoid losing content when the editor loses focus
+
 Version 3.5.1 (released 2024-07-28)
 
 - editor: fix jumping cursor to the top

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-forms",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Reusable React components for forms and other in Invenio",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",

--- a/src/lib/forms/RichInputField.js
+++ b/src/lib/forms/RichInputField.js
@@ -1,6 +1,7 @@
 // This file is part of React-Invenio-Deposit
 // Copyright (C) 2022 CERN.
 // Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2024 KTH Royal Institute of Technology.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -39,7 +40,8 @@ export class RichInputField extends Component {
           editor
         ) : (
           <RichEditor
-            value={value}
+            initialValue={initialValue}
+            inputValue={() => value} // () =>  To avoid re-rendering
             optimized
             editorConfig={editorConfig}
             onBlur={(event, editor) => {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Added missing initialValue prop for RichInputField
* Update prop value to inputValue 
* This will fix the input text issue in deposit pages, and communities settings pages
* Request comments work as expected.

> Communities Invite members still need to be fixed

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2771

I'm currently on vacation, from a quick test when I changed `inputValue` to a function in the `RichEditor` instead of the `RichInputField`, it caused request comments to not clear the input after submission. This PR satisfies all editors except the "[community members invite](https://github.com/inveniosoftware/invenio-communities/compare/master...Samk13:invenio-communities:fix-richEditor-invitation-modal)" editor, for which I can submit a similar fix if we agree.

Feel free to implement a better solution if found.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
