### PR TITLE
affiliations: fix display value after saving form

### DIFF
--- a/src/lib/elements/contrib/invenioRDM/records/AffiliationsSuggestions.js
+++ b/src/lib/elements/contrib/invenioRDM/records/AffiliationsSuggestions.js
@@ -86,6 +86,7 @@ export const AffiliationsSuggestions = (creatibutors, isOrganization) => {
       value: creatibutor.name,
       extra: creatibutor,
       key: creatibutor.name,
+      name: creatibutor.name,
       id: creatibutor.id,
       content: (
         <Header>


### PR DESCRIPTION
* Fixes a display issue where the selected affiliation value is not
  displayed on the form after saving/closing the creator modal.


https://github.com/user-attachments/assets/a28bdd2b-25c9-4b65-b8b7-28cbd8b128b1

