### PR TITLE
utils: updated string error handling in flattenAndCategorizeErrors

### DIFF
--- a/src/lib/utils/flattenAndCategorizeErrors.js
+++ b/src/lib/utils/flattenAndCategorizeErrors.js
@@ -5,14 +5,16 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 export function flattenAndCategorizeErrors(obj, prefix = "") {
-  if (!obj || typeof obj !== "object") {
-    throw Error("Invalid input: expected an object");
-  }
-
   const flattenedErrors = {};
   const severityChecks = {};
 
-  // Handle direct severity-based error objects
+  // If obj is a string, treat it as a single error message i.e. old error format
+  if (typeof obj === "string") {
+    flattenedErrors[prefix || "error"] = obj;
+    return { flattenedErrors, severityChecks };
+  }
+
+  // Handle direct severity-based error objects i.e. new error format
   if (obj.message && obj.severity) {
     severityChecks[prefix || "error"] = obj;
     return { flattenedErrors, severityChecks };


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes Issue https://github.com/inveniosoftware/invenio-rdm-records/issues/1980



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
