### PR TITLE
forms: FeedbackLabel: fix new prop not displayed due to state usage

### DIFF
--- a/src/lib/forms/FeedbackLabel.js
+++ b/src/lib/forms/FeedbackLabel.js
@@ -5,10 +5,9 @@ import { InvenioPopup } from "../elements/accessibility";
 import PropTypes from "prop-types";
 
 export class FeedbackLabel extends Component {
-  constructor(props) {
-    super(props);
+  render() {
+    const { errorMessage, pointing } = this.props;
 
-    const { errorMessage } = props;
     const { flattenedErrors = {}, severityChecks = {} } =
       flattenAndCategorizeErrors(errorMessage);
 
@@ -20,16 +19,7 @@ export class FeedbackLabel extends Component {
     const severityLevel = severityData?.severity || "";
     const severityMessage = severityData?.message || "";
     const severityDescription = severityData?.description || "";
-
-    this.state = {
-      errorText,
-      severityInfo: { severityLevel, severityMessage, severityDescription },
-    };
-  }
-
-  render() {
-    const { errorText, severityInfo } = this.state;
-    const { pointing } = this.props;
+    const severityInfo = { severityLevel, severityMessage, severityDescription };
 
     const hasError = errorText !== "" || severityInfo.severityLevel === "error";
     const className = hasError ? "prompt" : severityInfo.severityLevel;


### PR DESCRIPTION
Fixes inveniosoftware/invenio-rdm-records#1980

How to reproduce the problem:

1. Choose resource type journal article
2. Choose a wrong license
3. Save
4. The journal article license message appears
5. Choose resource type book
6. Save
7. The backend is sending the new book license message, but the frontend still shows the old journal article message