### PR TITLE
fix: rely on CSS for accordion icon rotation

### DIFF
--- a/src/lib/forms/AccordionField.js
+++ b/src/lib/forms/AccordionField.js
@@ -188,8 +188,7 @@ export class AccordionField extends Component {
             includesPaths={includesPaths}
             severityChecks={severityChecks}
           />
-          {/* Toggle Icon */}
-          <Icon name={activeIndex === 0 ? "angle down" : "angle right"} />
+          <Icon name="caret right" />
         </Accordion.Title>
         <Accordion.Content active={activeIndex === 0}>
           <Container>{children}</Container>


### PR DESCRIPTION
### Description

* Ensures icons rotate based on CSS instead of a JS icon name change when accordions are opened/closed

* This also means the rotation is now also animated.

* Related to https://github.com/inveniosoftware/invenio-app-rdm/issues/3059, where the CSS is modified to accommodate this change. These two PRs should be released at the same time to avoid small design bugs.