### PR TITLE
fix: more consistent props across fields

### DIFF
--- a/src/lib/forms/ArrayField.js
+++ b/src/lib/forms/ArrayField.js
@@ -90,6 +90,8 @@ export class ArrayField extends Component {
     const valuesToDisplay = this.getValues(values, fieldPath);
     return (
       <Form.Field {...uiProps} {...hasError}>
+        {helpText && <label className="helptext">{helpText}</label>}
+
         <FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />
 
         {valuesToDisplay.map((value, index, array) => {
@@ -111,8 +113,6 @@ export class ArrayField extends Component {
             </div>
           );
         })}
-
-        {helpText && <label className="helptext">{helpText}</label>}
 
         <Form.Group>
           <Form.Button

--- a/src/lib/forms/RichInputField.js
+++ b/src/lib/forms/RichInputField.js
@@ -15,7 +15,9 @@ import { Form } from "semantic-ui-react";
 
 export class RichInputField extends Component {
   renderFormField = (formikBag) => {
-    const { fieldPath, label, required, className, editor, editorConfig } = this.props;
+    const { fieldPath, label, required, className, editor, editorConfig, disabled } =
+      this.props;
+
     const value = getIn(formikBag.form.values, fieldPath, "");
     const initialValue = getIn(formikBag.form.initialValues, fieldPath, "");
     const error =
@@ -30,6 +32,7 @@ export class RichInputField extends Component {
         required={required}
         error={error}
         className={className}
+        disabled={disabled}
       >
         {React.isValidElement(label) ? (
           label
@@ -48,6 +51,7 @@ export class RichInputField extends Component {
               formikBag.form.setFieldValue(fieldPath, editor.getContent());
               formikBag.form.setFieldTouched(fieldPath, true);
             }}
+            disabled={disabled}
           />
         )}
         <ErrorLabel fieldPath={fieldPath} />
@@ -57,7 +61,6 @@ export class RichInputField extends Component {
 
   render() {
     const { optimized, fieldPath } = this.props;
-
     const FormikField = optimized ? FastField : Field;
 
     return (
@@ -74,6 +77,7 @@ RichInputField.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   required: PropTypes.bool,
   editorConfig: PropTypes.object,
+  disabled: PropTypes.bool,
 };
 
 RichInputField.defaultProps = {
@@ -83,4 +87,5 @@ RichInputField.defaultProps = {
   label: "",
   editor: undefined,
   editorConfig: undefined,
+  disabled: false,
 };

--- a/src/lib/forms/SelectField.js
+++ b/src/lib/forms/SelectField.js
@@ -53,6 +53,8 @@ export class SelectField extends Component {
       onChange,
       onAddItem,
       multiple,
+      disabled,
+      required,
       ...uiProps
     } = cmpProps;
     const _defaultValue = multiple ? [] : "";
@@ -66,6 +68,8 @@ export class SelectField extends Component {
         error={this.renderError(meta, initialValue, initialErrors, value, errors)}
         label={{ children: label }}
         name={fieldPath}
+        disabled={disabled}
+        required={required}
         onBlur={handleBlur}
         onChange={(event, data) => {
           if (onChange) {
@@ -90,15 +94,18 @@ export class SelectField extends Component {
   };
 
   render() {
-    const { optimized, fieldPath, ...uiProps } = this.props;
+    const { optimized, fieldPath, helpText, ...uiProps } = this.props;
     const FormikField = optimized ? FastField : Field;
     return (
-      <FormikField
-        name={fieldPath}
-        component={this.renderFormField}
-        fieldPath={fieldPath}
-        {...uiProps}
-      />
+      <>
+        <FormikField
+          name={fieldPath}
+          component={this.renderFormField}
+          fieldPath={fieldPath}
+          {...uiProps}
+        />
+        {helpText && <label className="helptext">{helpText}</label>}
+      </>
     );
   }
 }
@@ -113,6 +120,7 @@ SelectField.propTypes = {
   onChange: PropTypes.func,
   onAddItem: PropTypes.func,
   multiple: PropTypes.bool,
+  helpText: PropTypes.string,
 };
 
 SelectField.defaultProps = {
@@ -123,4 +131,5 @@ SelectField.defaultProps = {
   onChange: undefined,
   onAddItem: undefined,
   multiple: false,
+  helpText: undefined,
 };

--- a/src/lib/forms/TextField.js
+++ b/src/lib/forms/TextField.js
@@ -31,6 +31,8 @@ export class TextField extends Component {
           className="invenio-text-input-field"
           id={fieldPath}
           name={fieldPath}
+          required={required}
+          disabled={disabled}
         >
           {({ field, meta }) => {
             const computedError =

--- a/src/lib/forms/widgets/custom_fields/SubjectAutocompleteDropdown.js
+++ b/src/lib/forms/widgets/custom_fields/SubjectAutocompleteDropdown.js
@@ -36,6 +36,7 @@ export class SubjectAutocompleteDropdown extends Component {
       width,
       allowAdditions,
       noQueryMessage,
+      disabled,
       ...uiProps
     } = this.props;
     const labelContent = label ? (
@@ -87,6 +88,7 @@ export class SubjectAutocompleteDropdown extends Component {
             value={getIn(values, fieldPath, []).map((val) => val.id ?? val.subject)}
             allowAdditions={allowAdditions}
             width={width}
+            disabled={disabled}
           />
         )}
       </Field>
@@ -106,6 +108,7 @@ SubjectAutocompleteDropdown.propTypes = {
   width: PropTypes.number,
   allowAdditions: PropTypes.bool,
   noQueryMessage: PropTypes.string,
+  disabled: PropTypes.bool,
 };
 
 SubjectAutocompleteDropdown.defaultProps = {
@@ -119,4 +122,5 @@ SubjectAutocompleteDropdown.defaultProps = {
   width: undefined,
   noQueryMessage: "Search or create subjects...",
   allowAdditions: true,
+  disabled: false,
 };


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3103

**Please release at the same time as https://github.com/inveniosoftware/invenio-rdm-records/pull/2101**

---

:heart: Thank you for your contribution!

### Description

This PR contains some changes that will help make overriding deposit form fields more predictable and consistent once https://github.com/inveniosoftware/invenio-rdm-records/pull/2101 is also merged.

* Added the `disabled` and `required` props to `SubjectAutocompleteDropdown`, `SelectField`, `TextField`, `RichInputField`

* Moved the `helpText` to be shown above `ArrayField` rather than below it for a neater appearance (this was already the behaviour in some fields of the deposit form, where a custom help text component was being added instead of simply using the prop, for example in [`RelatedWorksField`](https://github.com/inveniosoftware/invenio-rdm-records/blob/3b7c4b6ec55742cd371bde01a487096ae9923dff/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/RelatedWorksField/RelatedWorksField.js#L32-L36)). See the examples below:

  <details>
    <summary>See examples</summary>

     <p><strong>Already existing manual helptext component:</strong></p>
     <img width="623" height="281" alt="image" src="https://github.com/user-attachments/assets/e0453292-cb30-42c9-a3d3-a7fd39e7c866" />
    
     <p><strong>New helptext added via prop:</strong></p>
     <img width="438" height="298" alt="image" src="https://github.com/user-attachments/assets/f9176065-5eb1-44c1-8b2d-7dd495b510d2" />
  </details>

* Added support for `helpText` to the `SelectField`
  
  <details>
    <summary>See example</summary>
    <img width="1144" height="136" alt="image" src="https://github.com/user-attachments/assets/305d53be-60af-46bd-847e-0dbc929d50a5" />
  </details>