### PR TITLE
overridable: Implement for custom fields

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,6 @@
 extends:
   - "@inveniosoftware/eslint-config-invenio"
   - "@inveniosoftware/eslint-config-invenio/prettier"
+
+rules:
+  react/default-props-match-prop-types: off

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+Version 4.11.0 (release 2025-09-10)
+
+- forms: Implement overridable support for custom field widgets, based on a dynamic ID passed in as a prop
+- forms: More consistent props across custom field widgets to increase consistency with https://github.com/inveniosoftware/invenio-rdm-records/pull/2101
+
 Version 4.10.1 (release 2025-07-31)
 
 - RemoteSelectField: Show default search results after selection/addition

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "query-string": "^7.0.0",
         "react": "^16.13.0",
         "react-dom": "^16.13.0",
-        "react-overridable": "^0.0.3",
+        "react-overridable": "^0.0.4",
         "semantic-ui-css": "^2.4.0",
         "semantic-ui-react": "^2.1.0",
         "tinymce": "^6.7.2",
@@ -11300,21 +11300,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -19701,7 +19686,6 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -19734,15 +19718,16 @@
       "license": "MIT"
     },
     "node_modules/react-overridable": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/react-overridable/-/react-overridable-0.0.3.tgz",
-      "integrity": "sha512-BlDKflgyXDAbSO1xST2gXw5ZYAnVoazhaOodzgQAFbtS6r2+qJGMfz3WQblrLWR57Tu7KYT2mKZ6a1o/zdAzKw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/react-overridable/-/react-overridable-0.0.4.tgz",
+      "integrity": "sha512-kphbIMXJj4mKJ0ZdkcwkimoORiDRvjaMnDGHjsg1AYdDgsi7UNKFcl4t4JZ7V0VDyIWsLEhJrj2v4FiTT8wh3g==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@babel/runtime": "^7.9.0",
         "prop-types": "^15.7.0",
-        "react": "^16.13.0"
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/react-popper": {
@@ -20933,7 +20918,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-invenio-forms",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-invenio-forms",
-      "version": "4.10.1",
+      "version": "4.11.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "semantic-ui-css": "^2.4.0",
     "semantic-ui-react": "^2.1.0",
     "tinymce": "^6.7.2",
-    "react-overridable": "^0.0.3",
+    "react-overridable": "^0.0.4",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-forms",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "description": "Reusable React components for forms and other in Invenio",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",

--- a/src/lib/forms/RichInputField.js
+++ b/src/lib/forms/RichInputField.js
@@ -15,9 +15,16 @@ import { Form } from "semantic-ui-react";
 
 export class RichInputField extends Component {
   renderFormField = (formikBag) => {
-    const { fieldPath, label, required, className, editor, editorConfig, disabled } =
-      this.props;
-
+    const {
+      fieldPath,
+      label,
+      required,
+      className,
+      editor,
+      editorConfig,
+      disabled,
+      optimized,
+    } = this.props;
     const value = getIn(formikBag.form.values, fieldPath, "");
     const initialValue = getIn(formikBag.form.initialValues, fieldPath, "");
     const error =
@@ -30,9 +37,9 @@ export class RichInputField extends Component {
       <Form.Field
         id={fieldPath}
         required={required}
+        disabled={disabled}
         error={error}
         className={className}
-        disabled={disabled}
       >
         {React.isValidElement(label) ? (
           label
@@ -45,7 +52,7 @@ export class RichInputField extends Component {
           <RichEditor
             initialValue={initialValue}
             inputValue={() => value} // () =>  To avoid re-rendering
-            optimized
+            optimized={optimized}
             editorConfig={editorConfig}
             onBlur={(event, editor) => {
               formikBag.form.setFieldValue(fieldPath, editor.getContent());
@@ -60,11 +67,14 @@ export class RichInputField extends Component {
   };
 
   render() {
-    const { optimized, fieldPath } = this.props;
+    const { optimized, fieldPath, helpText } = this.props;
     const FormikField = optimized ? FastField : Field;
 
     return (
-      <FormikField id={fieldPath} name={fieldPath} component={this.renderFormField} />
+      <>
+        <FormikField id={fieldPath} name={fieldPath} component={this.renderFormField} />
+        {helpText && <label className="helptext">{helpText}</label>}
+      </>
     );
   }
 }
@@ -78,6 +88,7 @@ RichInputField.propTypes = {
   required: PropTypes.bool,
   editorConfig: PropTypes.object,
   disabled: PropTypes.bool,
+  helpText: PropTypes.string,
 };
 
 RichInputField.defaultProps = {
@@ -88,4 +99,5 @@ RichInputField.defaultProps = {
   editor: undefined,
   editorConfig: undefined,
   disabled: false,
+  helpText: undefined,
 };

--- a/src/lib/forms/fieldComponents.js
+++ b/src/lib/forms/fieldComponents.js
@@ -5,7 +5,88 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import { useFormikContext } from "formik";
-import * as React from "react";
+import React from "react";
+import PropTypes from "prop-types";
+import Overridable from "react-overridable";
+
+// Props used for fields that are mandatory for all records
+export const mandatoryFieldCommonProps = {
+  fieldPath: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  labelIcon: PropTypes.string,
+  helpText: PropTypes.string,
+  placeholder: PropTypes.string,
+};
+
+// Also includes props that allow not including a field in the form, which are not applicable
+// to mandatory fields.
+export const fieldCommonProps = {
+  ...mandatoryFieldCommonProps,
+  hidden: PropTypes.bool,
+  disabled: PropTypes.bool,
+  required: PropTypes.bool,
+};
+
+/**
+ * Creates a component that de-renders when the `hidden` prop is `true`.
+ * All props passed to the `ShowHideComponent` are forwarded to the child component except the `hidden` prop.
+ *
+ * @param Component - The child component
+ * @param {string=} id - An optional OverridableID for debugging purposes
+ */
+const showHideComponent = (Component, id) => {
+  const ShowHideComponent = ({ hidden, ...props }) => {
+    if (props.disabled && props.required) {
+      throw new Error(`Cannot make field component ${id} both required and disabled`);
+    }
+    if (hidden) return null;
+    return <Component {...props} />;
+  };
+
+  ShowHideComponent.displayName = `ShowHide(${
+    Component.displayName || Component.name
+  })`;
+  ShowHideComponent.propTypes = { ...Component.propTypes };
+  ShowHideComponent.defaultProps = { ...Component.defaultProps };
+  return ShowHideComponent;
+};
+
+/**
+ * Creates an overridable component with show/hide functionality based on the `hidden` prop.
+ * All high-level fields in the deposit form are exported through this function, and this
+ * is the only version of the component that should be exported.
+ *
+ * @param {string} id - The Overridable ID to use
+ * @param Child - The unexported child component
+ */
+export const showHideOverridable = (id, Child) => {
+  const Component = showHideComponent(Child);
+  Component.propTypes = Child.propTypes;
+  return Overridable.component(id, Component);
+};
+
+/**
+ * Create a component whos Overridable ID is defined via a prop at runtime rather than pre-assigned.
+ * This is necessary for custom fields, where Python will inject the Overridable ID from the user's
+ * configuration, allowing features like `parametrize` to be applied also to custom fields.
+ */
+export const showHideOverridableWithDynamicId = (Widget) => {
+  const ShowHideWidget = showHideComponent(Widget);
+  const Component = ({ id, ...props }) => {
+    if (id === undefined) return <ShowHideWidget {...props} />;
+
+    return (
+      <Overridable id={id} {...props}>
+        <ShowHideWidget {...props} />
+      </Overridable>
+    );
+  };
+
+  Component.propTypes = { ...Widget.propTypes, id: PropTypes.string };
+  Component.defaultProps = { ...Widget.defaultProps, id: undefined };
+  Component.displayName = `DynamicOverridable(${Widget.displayName || Widget.name})`;
+  return Component;
+};
 
 /**
  * Override the parameters of a component (similarly to `parametrize`) using certain available

--- a/src/lib/forms/index.js
+++ b/src/lib/forms/index.js
@@ -25,5 +25,11 @@ export { RadioField } from "./RadioField";
 export { RichInputField } from "./RichInputField";
 export { RichEditor } from "./RichEditor";
 export { ToggleField } from "./ToggleField";
-export { parametrizeWithFormContext } from "./fieldComponents.js";
 export * from "./widgets";
+export {
+  showHideOverridable,
+  showHideOverridableWithDynamicId,
+  fieldCommonProps,
+  mandatoryFieldCommonProps,
+  parametrizeWithFormContext,
+} from "./fieldComponents";

--- a/src/lib/forms/widgets/array/Array.js
+++ b/src/lib/forms/widgets/array/Array.js
@@ -1,10 +1,13 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import { FieldLabel } from "../../FieldLabel";
 import { ArrayField } from "../../ArrayField";
+import {
+  fieldCommonProps,
+  showHideOverridableWithDynamicId,
+} from "../../fieldComponents";
 
-export default class Array extends Component {
+class ArrayComponent extends Component {
   render() {
     const {
       fieldPath,
@@ -17,16 +20,21 @@ export default class Array extends Component {
       addButtonLabel,
       defaultNewValue,
       className,
+      helpText: helpTextProp,
+      labelIcon: labelIconProp,
     } = this.props;
+
+    const helpText = helpTextProp ?? description;
+    const labelIcon = labelIconProp ?? icon;
 
     return (
       <ArrayField
         key={fieldPath}
         fieldPath={fieldPath}
         required={required}
-        helpText={description}
+        helpText={helpText}
         disabled={disabled}
-        label={<FieldLabel htmlFor={fieldPath} icon={icon} label={label} />}
+        label={<FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />}
         addButtonLabel={addButtonLabel}
         defaultNewValue={defaultNewValue}
         className={className}
@@ -37,22 +45,25 @@ export default class Array extends Component {
   }
 }
 
-Array.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-  icon: PropTypes.string,
-  required: PropTypes.bool,
-  disabled: PropTypes.bool,
+ArrayComponent.propTypes = {
   children: PropTypes.func.isRequired,
   addButtonLabel: PropTypes.string.isRequired,
   defaultNewValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   className: PropTypes.string,
+  /**
+   * @deprecated Use `labelIcon` instead
+   */
+  icon: PropTypes.string,
+  /**
+   * @deprecated Use `helpText` instead
+   */
+  description: PropTypes.string.isRequired,
+  ...fieldCommonProps,
 };
 
-Array.defaultProps = {
-  icon: undefined,
-  required: false,
-  disabled: false,
+ArrayComponent.defaultProps = {
   className: "",
+  icon: undefined,
 };
+
+export const Array = showHideOverridableWithDynamicId(ArrayComponent);

--- a/src/lib/forms/widgets/array/index.js
+++ b/src/lib/forms/widgets/array/index.js
@@ -1,1 +1,1 @@
-export { default as Array } from "./Array";
+export { Array } from "./Array";

--- a/src/lib/forms/widgets/select/AutocompleteDropdown.js
+++ b/src/lib/forms/widgets/select/AutocompleteDropdown.js
@@ -6,8 +6,12 @@ import _isArray from "lodash/isArray";
 import { Field } from "formik";
 import { FieldLabel } from "../../FieldLabel";
 import { RemoteSelectField } from "../../RemoteSelectField";
+import {
+  fieldCommonProps,
+  showHideOverridableWithDynamicId,
+} from "../../fieldComponents";
 
-export default class AutocompleteDropdown extends Component {
+class AutocompleteDropdownComponent extends Component {
   render() {
     const {
       description,
@@ -20,11 +24,18 @@ export default class AutocompleteDropdown extends Component {
       multiple,
       autocompleteFrom,
       autocompleteFromAcceptHeader,
+      helpText: helpTextProp,
+      labelIcon: labelIconProp,
+      disabled,
       ...dropdownProps
     } = this.props;
+
+    const helpText = helpTextProp ?? description;
+    const labelIcon = labelIconProp ?? icon;
+
     return (
       <>
-        <FieldLabel htmlFor={fieldPath} icon={icon} label={label} />
+        <FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />
         <Field name={fieldPath}>
           {({ form: { values } }) => {
             return (
@@ -39,6 +50,8 @@ export default class AutocompleteDropdown extends Component {
                 suggestionAPIHeaders={{
                   Accept: autocompleteFromAcceptHeader,
                 }}
+                disabled={disabled}
+                helpText={helpText}
                 serializeSuggestions={(suggestions) => {
                   return _isArray(suggestions)
                     ? suggestions.map((item) => ({
@@ -60,29 +73,36 @@ export default class AutocompleteDropdown extends Component {
             );
           }}
         </Field>
-        {description && <label className="helptext">{description}</label>}
       </>
     );
   }
 }
 
-AutocompleteDropdown.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+AutocompleteDropdownComponent.propTypes = {
   placeholder: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
   autocompleteFrom: PropTypes.string.isRequired,
   autocompleteFromAcceptHeader: PropTypes.string,
-  icon: PropTypes.string,
   clearable: PropTypes.bool,
   multiple: PropTypes.bool,
-  required: PropTypes.bool,
+  /**
+   * @deprecated Use `helpText` instead
+   */
+  description: PropTypes.string,
+  /**
+   * @deprecated Use `labelIcon` instead
+   */
+  icon: PropTypes.string,
+  ...fieldCommonProps,
 };
 
-AutocompleteDropdown.defaultProps = {
-  icon: undefined,
+AutocompleteDropdownComponent.defaultProps = {
   autocompleteFromAcceptHeader: "application/vnd.inveniordm.v1+json",
   clearable: false,
   multiple: false,
-  required: false,
+  icon: undefined,
+  description: undefined,
 };
+
+export const AutocompleteDropdown = showHideOverridableWithDynamicId(
+  AutocompleteDropdownComponent
+);

--- a/src/lib/forms/widgets/select/Dropdown.js
+++ b/src/lib/forms/widgets/select/Dropdown.js
@@ -1,10 +1,13 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import { FieldLabel } from "../../FieldLabel";
 import { SelectField } from "../../SelectField";
+import {
+  fieldCommonProps,
+  showHideOverridableWithDynamicId,
+} from "../../fieldComponents";
 
-export default class Dropdown extends Component {
+class DropdownComponent extends Component {
   serializeOptions = (options) =>
     options?.map((option) => ({
       text: option.title_l10n,
@@ -15,62 +18,76 @@ export default class Dropdown extends Component {
   render() {
     const {
       description,
+      helpText: helpTextProp,
       placeholder,
       fieldPath,
       label,
       icon,
+      labelIcon: labelIconProp,
       options,
       search,
       multiple,
       clearable,
       required,
+      disabled,
+      optimized,
     } = this.props;
+
+    const helpText = helpTextProp ?? description;
+    const labelIcon = labelIconProp ?? icon;
+
     return (
-      <>
-        <SelectField
-          fieldPath={fieldPath}
-          label={<FieldLabel htmlFor={fieldPath} icon={icon} label={label} />}
-          options={this.serializeOptions(options)}
-          search={search}
-          aria-label={label}
-          multiple={multiple}
-          placeholder={{
-            role: "option",
-            content: placeholder,
-          }}
-          clearable={clearable}
-          required={required}
-          optimized
-          defaultValue={multiple ? [] : ""}
-        />
-        {description && <label className="helptext">{description}</label>}
-      </>
+      <SelectField
+        fieldPath={fieldPath}
+        label={<FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />}
+        options={this.serializeOptions(options)}
+        search={search}
+        aria-label={label}
+        multiple={multiple}
+        disabled={disabled}
+        placeholder={{
+          role: "option",
+          content: placeholder,
+        }}
+        clearable={clearable}
+        required={required}
+        defaultValue={multiple ? [] : ""}
+        helpText={helpText}
+        optimized={optimized}
+      />
     );
   }
 }
 
-Dropdown.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  placeholder: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+DropdownComponent.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       title_l10n: PropTypes.string.isRequired,
     })
   ).isRequired,
-  icon: PropTypes.string,
   search: PropTypes.bool,
   multiple: PropTypes.bool,
   clearable: PropTypes.bool,
-  required: PropTypes.bool,
+  /**
+   * @deprecated Use `helpText` instead
+   */
+  description: PropTypes.string,
+  /**
+   * @deprecated Use `labelIcon` instead
+   */
+  icon: PropTypes.string,
+  optimized: PropTypes.bool,
+  ...fieldCommonProps,
 };
 
-Dropdown.defaultProps = {
+DropdownComponent.defaultProps = {
   icon: undefined,
   search: false,
   multiple: false,
   clearable: true,
-  required: false,
+  description: undefined,
+  optimized: true,
 };
+
+export const Dropdown = showHideOverridableWithDynamicId(DropdownComponent);

--- a/src/lib/forms/widgets/select/index.js
+++ b/src/lib/forms/widgets/select/index.js
@@ -1,2 +1,2 @@
-export { default as AutocompleteDropdown } from "./AutocompleteDropdown";
-export { default as Dropdown } from "./Dropdown";
+export { AutocompleteDropdown } from "./AutocompleteDropdown";
+export { Dropdown } from "./Dropdown";

--- a/src/lib/forms/widgets/text/BooleanCheckbox.js
+++ b/src/lib/forms/widgets/text/BooleanCheckbox.js
@@ -12,8 +12,12 @@ import { FieldLabel } from "../../FieldLabel";
 import { RadioField } from "../../RadioField";
 
 import { useField } from "formik";
+import {
+  fieldCommonProps,
+  showHideOverridableWithDynamicId,
+} from "../../fieldComponents";
 
-export default function BooleanCheckbox({
+function BooleanCheckboxComponent({
   description,
   icon,
   falseLabel,
@@ -21,28 +25,34 @@ export default function BooleanCheckbox({
   label,
   trueLabel,
   required,
+  helpText: helpTextProp,
+  labelIcon: labelIconProp,
+  optimized,
 }) {
+  const helpText = helpTextProp ?? description;
+  const labelIcon = labelIconProp ?? icon;
+
   // eslint-disable-next-line no-unused-vars
   const [_, meta] = useField(fieldPath);
   return (
     <>
       <Form.Group inline className="mb-0">
         <Form.Field required={required}>
-          <FieldLabel htmlFor={fieldPath} icon={icon} label={label} />
+          <FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />
         </Form.Field>
         <RadioField
           fieldPath={fieldPath}
           label={trueLabel}
           checked={meta.value === true}
           value
-          optimized
+          optimized={optimized}
         />
         <RadioField
           fieldPath={fieldPath}
           label={falseLabel}
           checked={meta.value === false}
           value={false}
-          optimized
+          optimized={optimized}
         />
         {meta.error && (
           <Form.Field required={required} className="error">
@@ -52,22 +62,31 @@ export default function BooleanCheckbox({
           </Form.Field>
         )}
       </Form.Group>
-      {description && <label className="helptext">{description}</label>}
+      {helpText && <label className="helptext">{helpText}</label>}
     </>
   );
 }
 
-BooleanCheckbox.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+BooleanCheckboxComponent.propTypes = {
   trueLabel: PropTypes.string.isRequired,
   falseLabel: PropTypes.string.isRequired,
+  /**
+   * @deprecated Use `helpText` instead
+   */
   description: PropTypes.string.isRequired,
+  /**
+   * @deprecated Use `labelIcon` instead
+   */
   icon: PropTypes.string,
-  required: PropTypes.bool,
+  optimized: PropTypes.bool,
+  ...fieldCommonProps,
 };
 
-BooleanCheckbox.defaultProps = {
+BooleanCheckboxComponent.defaultProps = {
   icon: undefined,
-  required: false,
+  optimized: true,
 };
+
+export const BooleanCheckbox = showHideOverridableWithDynamicId(
+  BooleanCheckboxComponent
+);

--- a/src/lib/forms/widgets/text/Input.js
+++ b/src/lib/forms/widgets/text/Input.js
@@ -1,10 +1,13 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import { FieldLabel } from "../../FieldLabel";
 import { TextField } from "../../TextField";
+import {
+  fieldCommonProps,
+  showHideOverridableWithDynamicId,
+} from "../../fieldComponents";
 
-export default class Input extends Component {
+export class InputComponent extends Component {
   render() {
     const {
       fieldPath,
@@ -15,16 +18,21 @@ export default class Input extends Component {
       description,
       disabled,
       type,
+      helpText: helpTextProp,
+      labelIcon: labelIconProp,
     } = this.props;
+
+    const helpText = helpTextProp ?? description;
+    const labelIcon = labelIconProp ?? icon;
 
     return (
       <TextField
         key={fieldPath}
         fieldPath={fieldPath}
         required={required}
-        helpText={description}
+        helpText={helpText}
         disabled={disabled}
-        label={<FieldLabel htmlFor={fieldPath} icon={icon} label={label} />}
+        label={<FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />}
         placeholder={placeholder}
         type={type}
       />
@@ -32,20 +40,23 @@ export default class Input extends Component {
   }
 }
 
-Input.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  placeholder: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+InputComponent.propTypes = {
+  /**
+   * @deprecated Use `helpText` instead
+   */
+  description: PropTypes.string,
+  /**
+   * @deprecated Use `labelIcon` instead
+   */
   icon: PropTypes.string,
-  required: PropTypes.bool,
-  disabled: PropTypes.bool,
   type: PropTypes.string,
+  ...fieldCommonProps,
 };
 
-Input.defaultProps = {
+InputComponent.defaultProps = {
   icon: undefined,
-  required: false,
-  disabled: false,
+  description: undefined,
   type: "input",
 };
+
+export const Input = showHideOverridableWithDynamicId(InputComponent);

--- a/src/lib/forms/widgets/text/MultiInput.js
+++ b/src/lib/forms/widgets/text/MultiInput.js
@@ -1,11 +1,14 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { useFormikContext, getIn } from "formik";
-
 import { FieldLabel } from "../../FieldLabel";
 import { SelectField } from "../../SelectField";
+import {
+  fieldCommonProps,
+  showHideOverridableWithDynamicId,
+} from "../../fieldComponents";
 
-export default function MultiInput({
+function MultiInputComponent({
   additionLabel,
   description,
   placeholder,
@@ -13,6 +16,10 @@ export default function MultiInput({
   label,
   icon,
   required,
+  disabled,
+  helpText: helpTextProp,
+  labelIcon: labelIconProp,
+  optimized,
   ...uiProps
 }) {
   const [options, setOptions] = useState([]);
@@ -24,18 +31,22 @@ export default function MultiInput({
       value: item,
     }));
 
+  const helpText = helpTextProp ?? description;
+  const labelIcon = labelIconProp ?? icon;
+
   return (
     <>
       <SelectField
         fieldPath={fieldPath}
-        label={<FieldLabel htmlFor={fieldPath} icon={icon} label={label} />}
+        label={<FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />}
         options={serializeValues(getIn(values, fieldPath, []))}
         placeholder={placeholder}
         required={required}
+        disabled={disabled}
         search
         multiple
         clearable
-        optimized
+        optimized={optimized}
         defaultValue={[]}
         noResultsMessage={placeholder} // show the placeholder to instruct user how to add new values
         additionLabel={additionLabel}
@@ -50,23 +61,29 @@ export default function MultiInput({
         icon={null} // remove the dropdown caret icon to avoid confusion
         {...uiProps}
       />
-      {description && <label className="helptext">{description}</label>}
+      {helpText && <label className="helptext">{helpText}</label>}
     </>
   );
 }
 
-MultiInput.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  placeholder: PropTypes.string.isRequired,
+MultiInputComponent.propTypes = {
+  /**
+   * @deprecated Use `helpText` instead
+   */
   description: PropTypes.string.isRequired,
   additionLabel: PropTypes.string,
+  /**
+   * @deprecated Use `labelIcon` instead
+   */
   icon: PropTypes.string,
-  required: PropTypes.bool,
+  optimized: PropTypes.bool,
+  ...fieldCommonProps,
 };
 
-MultiInput.defaultProps = {
+MultiInputComponent.defaultProps = {
   additionLabel: undefined,
   icon: undefined,
-  required: false,
+  optimized: true,
 };
+
+export const MultiInput = showHideOverridableWithDynamicId(MultiInputComponent);

--- a/src/lib/forms/widgets/text/NumberInput.js
+++ b/src/lib/forms/widgets/text/NumberInput.js
@@ -1,5 +1,6 @@
 import React from "react";
-import Input from "./Input";
+import { showHideOverridableWithDynamicId } from "../../fieldComponents";
+import { InputComponent } from "./Input";
 
-const NumberInput = (props) => <Input {...props} type="number" />;
-export default NumberInput;
+const NumberInputComponent = (props) => <InputComponent {...props} type="number" />;
+export const NumberInput = showHideOverridableWithDynamicId(NumberInputComponent);

--- a/src/lib/forms/widgets/text/RichInput.js
+++ b/src/lib/forms/widgets/text/RichInput.js
@@ -1,38 +1,65 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import { FieldLabel } from "../../FieldLabel";
 import { RichInputField } from "../../RichInputField";
+import {
+  fieldCommonProps,
+  showHideOverridableWithDynamicId,
+} from "../../fieldComponents";
 
-export default class RichInput extends Component {
+class RichInputComponent extends Component {
   render() {
-    const { fieldPath, required, label, icon, description, editorConfig } = this.props;
+    const {
+      fieldPath,
+      required,
+      label,
+      icon,
+      description,
+      editorConfig,
+      disabled,
+      helpText: helpTextProp,
+      labelIcon: labelIconProp,
+      optimized,
+    } = this.props;
+
+    const helpText = helpTextProp ?? description;
+    const labelIcon = labelIconProp ?? icon;
+
     return (
       <>
         <RichInputField
           key={fieldPath}
           fieldPath={fieldPath}
           required={required}
+          disabled={disabled}
           editorConfig={editorConfig}
-          label={<FieldLabel htmlFor={fieldPath} icon={icon} label={label} />}
+          label={<FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />}
+          optimized={optimized}
         />
-        {description && <label className="helptext">{description}</label>}
+        {helpText && <label className="helptext">{helpText}</label>}
       </>
     );
   }
 }
 
-RichInput.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+RichInputComponent.propTypes = {
   editorConfig: PropTypes.object,
+  /**
+   * @deprecated Use `labelIcon` instead
+   */
   icon: PropTypes.string,
-  required: PropTypes.bool,
+  /**
+   * @deprecated Use `helpText` instead
+   */
+  description: PropTypes.string.isRequired,
+  optimized: PropTypes.bool,
+  ...fieldCommonProps,
 };
 
-RichInput.defaultProps = {
+RichInputComponent.defaultProps = {
   icon: undefined,
   editorConfig: {},
-  required: false,
+  optimized: true,
 };
+
+export const RichInput = showHideOverridableWithDynamicId(RichInputComponent);

--- a/src/lib/forms/widgets/text/TextArea.js
+++ b/src/lib/forms/widgets/text/TextArea.js
@@ -1,12 +1,28 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import { FieldLabel } from "../../FieldLabel";
 import { TextAreaField } from "../../TextAreaField";
+import {
+  fieldCommonProps,
+  showHideOverridableWithDynamicId,
+} from "../../fieldComponents";
 
-export default class TextArea extends Component {
+class TextAreaComponent extends Component {
   render() {
-    const { fieldPath, required, label, icon, description, rows } = this.props;
+    const {
+      fieldPath,
+      required,
+      label,
+      icon,
+      description,
+      rows,
+      disabled,
+      helpText: helpTextProp,
+      labelIcon: labelIconProp,
+    } = this.props;
+
+    const helpText = helpTextProp ?? description;
+    const labelIcon = labelIconProp ?? icon;
 
     return (
       <>
@@ -14,26 +30,32 @@ export default class TextArea extends Component {
           key={fieldPath}
           fieldPath={fieldPath}
           required={required}
-          label={<FieldLabel htmlFor={fieldPath} icon={icon} label={label} />}
+          disabled={disabled}
           rows={rows}
+          label={<FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />}
         />
-        {description && <label className="helptext">{description}</label>}
+        {helpText && <label className="helptext">{helpText}</label>}
       </>
     );
   }
 }
 
-TextArea.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-  icon: PropTypes.string,
-  required: PropTypes.bool,
+TextAreaComponent.propTypes = {
   rows: PropTypes.number,
+  /**
+   * @deprecated Use `labelIcon` instead
+   */
+  icon: PropTypes.string,
+  /**
+   * @deprecated Use `helpText` instead
+   */
+  description: PropTypes.string.isRequired,
+  ...fieldCommonProps,
 };
 
-TextArea.defaultProps = {
+TextAreaComponent.defaultProps = {
   icon: undefined,
-  required: false,
   rows: 3,
 };
+
+export const TextArea = showHideOverridableWithDynamicId(TextAreaComponent);

--- a/src/lib/forms/widgets/text/index.js
+++ b/src/lib/forms/widgets/text/index.js
@@ -1,6 +1,8 @@
-export { default as RichInput } from "./RichInput";
-export { default as TextArea } from "./TextArea";
-export { default as Input } from "./Input";
-export { default as MultiInput } from "./MultiInput";
-export { default as NumberInput } from "./NumberInput";
-export { default as BooleanCheckbox } from "./BooleanCheckbox";
+export { RichInput } from "./RichInput";
+export { TextArea } from "./TextArea";
+// InputComponent is exported too so other custom field implementations (e.g. in invenio-rdm-records) can
+// use the Input as a constituent part of a composite custom field
+export { Input, InputComponent } from "./Input";
+export { MultiInput } from "./MultiInput";
+export { NumberInput } from "./NumberInput";
+export { BooleanCheckbox } from "./BooleanCheckbox";


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/react-invenio-forms/issues/297

---

**This is a draft proposal of a solution for this issue, please let me know if you have any suggestions on how to better implement it.**

### Description

* This commit demonstrates a potential method of implementing `Overridable` support for custom fields.

* When creating a custom field [UI definition](https://inveniordm.docs.cern.ch/customize/metadata/custom_fields/records/#upload-deposit-form), the user simply has to specify an additional `id` prop with their desired ID value for the Overridable. Then, they can specify a `parametrize` in the `overridableRegistry/mapping.js` as usual.

* The aim is to have a set of common props that can be applied to all the field widgets, similarly to
https://github.com/inveniosoftware/invenio-app-rdm/issues/3103.

* This commit makes the necessary changes to two of the UI widgets as a demonstration. When parameterizing, the user has to reference e.g. `AutocompleteDropdownComponent` instead of `AutocompleteDropdown`. These are both exported.

* On its own, this feature is not helpful: users could simply change the props they assign in the Python dictionary instead of using an override. Instead, this is intended to be used in conjunction with `dynamicParametrize` (created in https://github.com/inveniosoftware/react-invenio-forms/pull/300) to allow users to dynamically change the props of their custom fields based on the form state.

### Full example

In the [custom fields definitions file](https://github.com/CERNDocumentServer/cds-rdm/blob/eb1f00ab3168327f8d637a6a732280cf025ecd90/assets/js/invenio_app_rdm/overridableRegistry/mapping.js):

```python
CERN_CUSTOM_FIELDS_UI = {
    "section": "CERN",
    "ui_widget": "CERNFields",
    "fields": [
        dict(
            field="cern:departments",
            ui_widget="Dropdown",
            display_url="https://scientific-info.cern/archives/history_CERN/internal_organisation/20s",
            props=dict(
                label="Department",
                icon="building",
                description="Please select a recognised department from the list if applicable e.g BE, EN, HR etc.",
                search=False,
                multiple=True,
                sort_by="title_sort",
                clearable=True,
                autocompleteFrom="/api/vocabularies/departments",
                id="CdsRdm.CustomFields.Department", # New added field
            ),
        ),
        # ...
```

Then, in `assets/js/invenio_app_rdm/overridableRegistry/mapping.js`:

```javascript
export const overriddenComponents = {
  "CdsRdm.CustomFields.Department": parametrize(DropdownComponent, {
    helpText: "Choose your favourite department",
    required: true,
  }),
}
```