### PR TITLE
fix(subjects-dropdown): add subject as key if id is missing

### DIFF
--- a/src/lib/forms/widgets/custom_fields/SubjectAutocompleteDropdown.js
+++ b/src/lib/forms/widgets/custom_fields/SubjectAutocompleteDropdown.js
@@ -11,7 +11,7 @@ export class SubjectAutocompleteDropdown extends Component {
       return {
         text: scheme + subject.subject,
         value: subject.id ?? subject.subject,
-        key: subject.id,
+        key: subject.id ?? subject.subject,
         ...(subject.id ? { id: subject.id } : {}),
         subject: subject.subject,
       };


### PR DESCRIPTION
fixes: https://github.com/CERNDocumentServer/cds-rdm/issues/530


https://github.com/user-attachments/assets/233a3c9e-9be1-4937-8df5-ce94beffbe5c

