### PR TITLE
fix: stale initialValue when components remonts

### DIFF
--- a/src/lib/forms/RichInputField.js
+++ b/src/lib/forms/RichInputField.js
@@ -50,7 +50,7 @@ export class RichInputField extends Component {
           editor
         ) : (
           <RichEditor
-            initialValue={initialValue}
+            initialValue={() => initialValue} // () =>  To avoid stale initialValue when remounting
             inputValue={() => value} // () =>  To avoid re-rendering
             optimized={optimized}
             editorConfig={editorConfig}


### PR DESCRIPTION
* when the fields is in arrayField, you fill something in it, save form
* then delete that entry from array field and add again, it still
* contains old value even though in formik that field is empty

:heart: Thank you for your contribution!

https://github.com/user-attachments/assets/2f64a046-64a6-4ea6-8055-e1068448b162


### Description

There is issue with stale initialValue when the component remounts. Meaning, after this happens, in formik, you have "" at that slot, but in the UI you see previously existing text. This then creates weird situations for the user, as he things he is sending one thing to the server, but it is actually nothing there. 