### PR TITLE
components: remove defaultProps from components

### DIFF
--- a/src/demos/App.js
+++ b/src/demos/App.js
@@ -27,10 +27,6 @@ CurrentRecord.propTypes = {
   record: PropTypes.object,
 };
 
-CurrentRecord.defaultProps = {
-  record: undefined,
-};
-
 class RecordPreviewer extends Component {
   render() {
     const { record } = this.props;
@@ -40,10 +36,6 @@ class RecordPreviewer extends Component {
 
 RecordPreviewer.propTypes = {
   record: PropTypes.object,
-};
-
-RecordPreviewer.defaultProps = {
-  record: undefined,
 };
 
 class App extends Component {

--- a/src/lib/elements/ErrorMessage.js
+++ b/src/lib/elements/ErrorMessage.js
@@ -86,11 +86,3 @@ ErrorMessage.propTypes = {
   content: PropTypes.string,
   icon: PropTypes.string,
 };
-
-ErrorMessage.defaultProps = {
-  errors: undefined,
-  header: undefined,
-  uiProps: undefined,
-  icon: undefined,
-  content: undefined,
-};

--- a/src/lib/elements/GridResponsiveSidebarColumn.js
+++ b/src/lib/elements/GridResponsiveSidebarColumn.js
@@ -79,13 +79,3 @@ GridResponsiveSidebarColumn.propTypes = {
   widescreen: PropTypes.number,
   ariaLabel: PropTypes.string,
 };
-
-GridResponsiveSidebarColumn.defaultProps = {
-  width: undefined,
-  mobile: undefined,
-  tablet: undefined,
-  computer: undefined,
-  widescreen: undefined,
-  largeScreen: undefined,
-  ariaLabel: undefined,
-};

--- a/src/lib/elements/Image.js
+++ b/src/lib/elements/Image.js
@@ -15,7 +15,11 @@ import axios from "axios";
  */
 export class Image extends Component {
   async componentDidMount() {
-    const { fallbackSrc, loadFallbackFirst, src } = this.props;
+    const {
+      fallbackSrc = "/static/images/square-placeholder.png",
+      loadFallbackFirst = false,
+      src,
+    } = this.props;
     if (loadFallbackFirst) {
       try {
         await axios.get(src);
@@ -51,8 +55,14 @@ export class Image extends Component {
   };
 
   render() {
-    const { alt, className, src, fallbackSrc, loadFallbackFirst, ...UIprops } =
-      this.props;
+    const {
+      alt = "No image found",
+      className = "",
+      src,
+      fallbackSrc = "/static/images/square-placeholder.png",
+      loadFallbackFirst = false,
+      ...UIprops
+    } = this.props;
     const loadingClass = !loadFallbackFirst
       ? `${className} placeholder`
       : `${className} fallback_image`;
@@ -88,11 +98,4 @@ Image.propTypes = {
   className: PropTypes.string,
   alt: PropTypes.string,
   loadFallbackFirst: PropTypes.bool,
-};
-
-Image.defaultProps = {
-  className: "",
-  alt: "No image found",
-  fallbackSrc: "/static/images/square-placeholder.png",
-  loadFallbackFirst: false,
 };

--- a/src/lib/elements/accessibility/InvenioPopup.js
+++ b/src/lib/elements/accessibility/InvenioPopup.js
@@ -12,13 +12,13 @@ export class InvenioPopup extends Component {
   render() {
     const {
       popupId,
-      size,
+      size = "small",
       trigger,
       content,
-      position,
-      inverted,
+      position = "top left",
+      inverted = false,
       ariaLabel,
-      hoverable,
+      hoverable = true,
     } = this.props;
 
     return (
@@ -53,11 +53,4 @@ InvenioPopup.propTypes = {
   hoverable: PropTypes.bool,
   position: PropTypes.string,
   size: PropTypes.string,
-};
-
-InvenioPopup.defaultProps = {
-  inverted: false,
-  position: "top left",
-  size: "small",
-  hoverable: true,
 };

--- a/src/lib/elements/bulk_actions/SearchResultsBulkActions.js
+++ b/src/lib/elements/bulk_actions/SearchResultsBulkActions.js
@@ -15,7 +15,7 @@ import _pickBy from "lodash/pickBy";
 export default class SearchResultsBulkActions extends Component {
   constructor(props) {
     super(props);
-    const { allSelected } = this.props;
+    const { allSelected = false } = this.props;
     this.state = { allSelectedChecked: allSelected };
   }
 
@@ -85,8 +85,4 @@ SearchResultsBulkActions.propTypes = {
   bulkDropdownOptions: PropTypes.array.isRequired,
   allSelected: PropTypes.bool,
   optionSelectionCallback: PropTypes.func.isRequired,
-};
-
-SearchResultsBulkActions.defaultProps = {
-  allSelected: false,
 };

--- a/src/lib/elements/contrib/invenioRDM/users/UserListItemCompact.js
+++ b/src/lib/elements/contrib/invenioRDM/users/UserListItemCompact.js
@@ -40,7 +40,3 @@ UserListItemCompact.propTypes = {
   id: PropTypes.string.isRequired,
   linkToDetailView: PropTypes.string,
 };
-
-UserListItemCompact.defaultProps = {
-  linkToDetailView: undefined,
-};

--- a/src/lib/forms/AccordionField.js
+++ b/src/lib/forms/AccordionField.js
@@ -106,7 +106,7 @@ class AccordionError extends Component {
 
   render() {
     const { errors } = this.state;
-    const { severityChecks } = this.props;
+    const { severityChecks = null } = this.props;
     if (errors === undefined) {
       return null;
     }
@@ -133,14 +133,10 @@ AccordionError.propTypes = {
   severityChecks: PropTypes.object,
 };
 
-AccordionError.defaultProps = {
-  severityChecks: null,
-};
-
 export class AccordionField extends Component {
   constructor(props) {
     super(props);
-    const { active } = this.props;
+    const { active = true } = this.props;
     this.state = { hasError: false, activeIndex: active ? 0 : -1 };
   }
 
@@ -155,7 +151,12 @@ export class AccordionField extends Component {
   };
 
   renderAccordion = (props) => {
-    const { label, children, includesPaths, severityChecks } = this.props;
+    const {
+      label = "",
+      children = null,
+      includesPaths = [],
+      severityChecks = null,
+    } = this.props;
     const { hasError, activeIndex } = this.state;
     // Omit props, so they don't get spread into Accordion https://react.semantic-ui.com/modules/accordion/#types-standard
     const uiProps = _omit(this.props, [
@@ -207,7 +208,7 @@ export class AccordionField extends Component {
   };
 
   render() {
-    const { optimized } = this.props;
+    const { optimized = false } = this.props;
     const FormikField = optimized ? FastField : Field;
     return <FormikField name="" component={this.renderAccordion} />;
   }
@@ -221,14 +222,4 @@ AccordionField.propTypes = {
   children: PropTypes.node,
   ui: PropTypes.object,
   severityChecks: PropTypes.object,
-};
-
-AccordionField.defaultProps = {
-  active: true,
-  includesPaths: [],
-  label: "",
-  optimized: false,
-  children: null,
-  ui: null,
-  severityChecks: null,
 };

--- a/src/lib/forms/ArrayField.js
+++ b/src/lib/forms/ArrayField.js
@@ -73,16 +73,16 @@ export class ArrayField extends Component {
       ...arrayHelpers
     } = props;
     const {
-      addButtonLabel,
-      addButtonClassName,
+      addButtonLabel = "Add new row",
+      addButtonClassName = "align-self-end mt-15",
       children,
       defaultNewValue,
       fieldPath,
-      label,
-      labelIcon,
-      helpText,
-      requiredOptions,
-      showEmptyValue,
+      label = "",
+      labelIcon = "",
+      helpText = "",
+      requiredOptions = [],
+      showEmptyValue = false,
       ...uiProps
     } = this.props;
     const hasError = this.hasGroupErrors(errors) ? { error: {} } : {};
@@ -159,14 +159,4 @@ ArrayField.propTypes = {
   labelIcon: PropTypes.string,
   requiredOptions: PropTypes.array,
   showEmptyValue: PropTypes.bool,
-};
-
-ArrayField.defaultProps = {
-  addButtonLabel: "Add new row",
-  addButtonClassName: "align-self-end mt-15",
-  helpText: "",
-  label: "",
-  labelIcon: "",
-  requiredOptions: [],
-  showEmptyValue: false,
 };

--- a/src/lib/forms/BaseForm/BaseForm.js
+++ b/src/lib/forms/BaseForm/BaseForm.js
@@ -30,7 +30,3 @@ BaseForm.propTypes = {
     validate: PropTypes.func,
   }),
 };
-
-BaseForm.defaultProps = {
-  formik: undefined,
-};

--- a/src/lib/forms/BooleanField.js
+++ b/src/lib/forms/BooleanField.js
@@ -22,7 +22,7 @@ export class BooleanField extends Component {
   }
 
   renderFormField = (props) => {
-    const { fieldPath, label, ...uiProps } = this.props;
+    const { fieldPath, label = "", ...uiProps } = this.props;
     const {
       form: { values, handleBlur, errors, initialErrors, initialValues, setFieldValue },
     } = props;
@@ -47,7 +47,7 @@ export class BooleanField extends Component {
     );
   };
   render() {
-    const { optimized, fieldPath } = this.props;
+    const { optimized = false, fieldPath } = this.props;
     const FormikField = optimized ? FastField : Field;
     return (
       <FormikField
@@ -63,9 +63,4 @@ BooleanField.propTypes = {
   fieldPath: PropTypes.string.isRequired,
   label: PropTypes.string,
   optimized: PropTypes.bool,
-};
-
-BooleanField.defaultProps = {
-  label: "",
-  optimized: false,
 };

--- a/src/lib/forms/FeedbackLabel.js
+++ b/src/lib/forms/FeedbackLabel.js
@@ -30,7 +30,7 @@ export class FeedbackLabel extends Component {
   };
 
   computeErrors = (errors, initialErrors) => {
-    const { fieldPath, injectedError, hasSubfields } = this.props;
+    const { fieldPath, injectedError, hasSubfields = false } = this.props;
     let error;
 
     if (injectedError) {
@@ -64,7 +64,7 @@ export class FeedbackLabel extends Component {
   };
 
   renderErrors = ({ form: { errors, initialErrors } }) => {
-    const { fieldPath, pointing } = this.props;
+    const { fieldPath, pointing = "left" } = this.props;
     const { error, errMessage, hasSeverity } = this.computeErrors(
       errors,
       initialErrors
@@ -110,11 +110,4 @@ FeedbackLabel.propTypes = {
   pointing: PropTypes.oneOf(["left", "above", "below", "right"]),
   fieldPath: PropTypes.string,
   hasSubfields: PropTypes.bool,
-};
-
-FeedbackLabel.defaultProps = {
-  injectedError: undefined,
-  pointing: "left",
-  fieldPath: undefined,
-  hasSubfields: false,
 };

--- a/src/lib/forms/FieldLabel.js
+++ b/src/lib/forms/FieldLabel.js
@@ -12,7 +12,12 @@ import { Icon } from "semantic-ui-react";
 
 export class FieldLabel extends Component {
   render() {
-    const { htmlFor, icon, label, className } = this.props;
+    const {
+      htmlFor,
+      icon = "",
+      label,
+      className = "field-label-class invenio-field-label",
+    } = this.props;
     return (
       <label htmlFor={htmlFor} className={className}>
         {icon ? <Icon name={icon} /> : null}
@@ -27,11 +32,4 @@ FieldLabel.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   icon: PropTypes.string,
   className: PropTypes.string,
-};
-
-FieldLabel.defaultProps = {
-  className: "field-label-class invenio-field-label",
-  icon: "",
-  htmlFor: undefined,
-  label: undefined,
 };

--- a/src/lib/forms/FilesList.js
+++ b/src/lib/forms/FilesList.js
@@ -49,8 +49,3 @@ FilesList.propTypes = {
   files: PropTypes.array,
   onFileDelete: PropTypes.func,
 };
-
-FilesList.defaultProps = {
-  files: undefined,
-  onFileDelete: undefined,
-};

--- a/src/lib/forms/GroupField.js
+++ b/src/lib/forms/GroupField.js
@@ -31,7 +31,14 @@ export class GroupField extends React.Component {
   };
 
   renderFormField = (props) => {
-    const { action, basic, border, children, fieldPath, ...uiProps } = props;
+    const {
+      action,
+      basic = false,
+      border = false,
+      children,
+      fieldPath = "",
+      ...uiProps
+    } = props;
     const errors = getIn(props, "form.errors");
     const classNames = ["form-group"];
     if (border) {
@@ -54,7 +61,7 @@ export class GroupField extends React.Component {
   };
 
   render() {
-    const { optimized, fieldPath, ...uiProps } = this.props;
+    const { optimized = false, fieldPath = "", ...uiProps } = this.props;
 
     const FormikField = optimized ? FastField : Field;
     return (
@@ -76,13 +83,4 @@ GroupField.propTypes = {
   action: PropTypes.any,
   basic: PropTypes.bool,
   children: PropTypes.any,
-};
-
-GroupField.defaultProps = {
-  border: false,
-  fieldPath: "",
-  optimized: false,
-  action: undefined,
-  basic: false,
-  children: undefined,
 };

--- a/src/lib/forms/RadioField.js
+++ b/src/lib/forms/RadioField.js
@@ -26,7 +26,15 @@ export class RadioField extends Component {
      * form: current Formik form (holds formik state that drives the UI)
      */
 
-    const { checked, fieldPath, label, labelIcon, onChange, value, ...ui } = this.props;
+    const {
+      checked = false,
+      fieldPath,
+      label = "",
+      labelIcon = "",
+      onChange,
+      value = "",
+      ...ui
+    } = this.props;
 
     const handleChange = (event, data) => {
       if (onChange) {
@@ -52,7 +60,7 @@ export class RadioField extends Component {
   };
 
   render() {
-    const { optimized, fieldPath } = this.props;
+    const { optimized = false, fieldPath } = this.props;
 
     const FormikField = optimized ? FastField : Field;
     return <FormikField name={fieldPath} component={this.renderFormField} />;
@@ -67,13 +75,4 @@ RadioField.propTypes = {
   optimized: PropTypes.bool,
   onChange: PropTypes.func,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
-};
-
-RadioField.defaultProps = {
-  checked: false,
-  label: "",
-  optimized: false,
-  labelIcon: "",
-  onChange: undefined,
-  value: "",
 };

--- a/src/lib/forms/RemoteSelectField.js
+++ b/src/lib/forms/RemoteSelectField.js
@@ -28,8 +28,12 @@ const serializeSuggestions = (suggestions) =>
 export class RemoteSelectField extends Component {
   constructor(props) {
     super(props);
-    const initialSuggestions = props.initialSuggestions
-      ? props.serializeSuggestions(props.initialSuggestions)
+    const {
+      initialSuggestions: _initialSuggestions = [],
+      serializeSuggestions: _serializeSuggestions = serializeSuggestions,
+    } = props;
+    const initialSuggestions = _initialSuggestions
+      ? _serializeSuggestions(_initialSuggestions)
       : [];
     this.state = {
       isFetching: false,
@@ -46,7 +50,7 @@ export class RemoteSelectField extends Component {
   }
 
   onSelectValue = async (event, { options, value, ...otherData }, callbackFunc) => {
-    const { multiple } = this.props;
+    const { multiple = false } = this.props;
     const newSelectedSuggestions = options.filter((item) => {
       if (multiple) {
         // "value" is an array so check if it includes the option's value
@@ -89,14 +93,20 @@ export class RemoteSelectField extends Component {
     await this.searchIfNoSuggestions(newSelectedSuggestions); // Reset search query to empty string after addition
   };
 
-  onSearchChange = _debounce(async (e, { searchQuery }) => {
-    this.cancellableAction && this.cancellableAction.cancel();
-    await this.executeSearch(searchQuery);
+  onSearchChange = _debounce(
+    async (e, { searchQuery }) => {
+      this.cancellableAction && this.cancellableAction.cancel();
+      await this.executeSearch(searchQuery);
+    },
     // eslint-disable-next-line react/destructuring-assignment
-  }, this.props.debounceTime); // can't destructure as prop variable is used outside the inner function
+    this.props.debounceTime ?? 500
+  ); // can't destructure as prop variable is used outside the inner function
 
   executeSearch = async (searchQuery) => {
-    const { preSearchChange, serializeSuggestions } = this.props;
+    const {
+      preSearchChange = (x) => x,
+      serializeSuggestions: _serializeSuggestions = serializeSuggestions,
+    } = this.props;
     const query = preSearchChange(searchQuery);
     // If there is no query change, then display prevState suggestions
     const { searchQuery: prevSearchQuery } = this.state;
@@ -107,7 +117,7 @@ export class RemoteSelectField extends Component {
     try {
       const suggestions = await this.fetchSuggestions(query);
 
-      const serializedSuggestions = serializeSuggestions(suggestions);
+      const serializedSuggestions = _serializeSuggestions(suggestions);
       this.setState((prevState) => ({
         suggestions: mergeOptions(prevState.selectedSuggestions, serializedSuggestions),
         isFetching: false,
@@ -134,9 +144,9 @@ export class RemoteSelectField extends Component {
   fetchSuggestions = async (searchQuery) => {
     const {
       suggestionAPIUrl,
-      suggestionAPIQueryParams,
-      suggestionAPIHeaders,
-      searchQueryParamName,
+      suggestionAPIQueryParams = {},
+      suggestionAPIHeaders = {},
+      searchQueryParamName = "suggest",
     } = this.props;
 
     this.cancellableAction = withCancel(
@@ -165,10 +175,10 @@ export class RemoteSelectField extends Component {
 
   getNoResultsMessage = () => {
     const {
-      loadingMessage,
-      suggestionsErrorMessage,
-      noQueryMessage,
-      noResultsMessage,
+      loadingMessage = "Loading...",
+      suggestionsErrorMessage = "Something went wrong...",
+      noQueryMessage = "Search...",
+      noResultsMessage = "No results found.",
     } = this.props;
     const { isFetching, error, searchQuery } = this.state;
     if (isFetching) {
@@ -188,7 +198,7 @@ export class RemoteSelectField extends Component {
   };
 
   onBlur = () => {
-    const { searchOnFocus } = this.props;
+    const { searchOnFocus = false } = this.props;
     this.setState((prevState) => ({
       open: false,
       error: false,
@@ -201,7 +211,7 @@ export class RemoteSelectField extends Component {
 
   onFocus = async () => {
     this.setState({ open: true });
-    const { searchOnFocus } = this.props;
+    const { searchOnFocus = false } = this.props;
     if (searchOnFocus) {
       const { searchQuery } = this.state;
       await this.executeSearch(searchQuery || "");
@@ -212,21 +222,23 @@ export class RemoteSelectField extends Component {
     const {
       fieldPath,
       suggestionAPIUrl,
-      suggestionAPIQueryParams,
-      serializeSuggestions,
+      suggestionAPIQueryParams = {},
+      serializeSuggestions: _serializeSuggestions = serializeSuggestions,
       serializeAddedValue,
-      suggestionAPIHeaders,
-      debounceTime,
-      searchQueryParamName,
-      noResultsMessage,
-      loadingMessage,
-      suggestionsErrorMessage,
-      noQueryMessage,
-      initialSuggestions,
-      preSearchChange,
+      suggestionAPIHeaders = {},
+      debounceTime = 500,
+      searchQueryParamName = "suggest",
+      noResultsMessage = "No results found.",
+      loadingMessage = "Loading...",
+      suggestionsErrorMessage = "Something went wrong...",
+      noQueryMessage = "Search...",
+      initialSuggestions = [],
+      preSearchChange = (x) => x,
       onValueChange,
-      search,
-      isFocused,
+      search = true,
+      isFocused = false,
+      multiple = false,
+      searchOnFocus = false,
       ...uiProps
     } = this.props;
     const compProps = {
@@ -234,7 +246,7 @@ export class RemoteSelectField extends Component {
       suggestionAPIUrl,
       suggestionAPIQueryParams,
       suggestionAPIHeaders,
-      serializeSuggestions,
+      serializeSuggestions: _serializeSuggestions,
       serializeAddedValue,
       debounceTime,
       searchQueryParamName,
@@ -324,24 +336,4 @@ RemoteSelectField.propTypes = {
   multiple: PropTypes.bool,
   isFocused: PropTypes.bool,
   searchOnFocus: PropTypes.bool,
-};
-
-RemoteSelectField.defaultProps = {
-  debounceTime: 500,
-  suggestionAPIQueryParams: {},
-  suggestionAPIHeaders: {},
-  serializeSuggestions: serializeSuggestions,
-  searchQueryParamName: "suggest",
-  suggestionsErrorMessage: "Something went wrong...",
-  noQueryMessage: "Search...",
-  noResultsMessage: "No results found.",
-  loadingMessage: "Loading...",
-  preSearchChange: (x) => x,
-  search: true,
-  multiple: false,
-  serializeAddedValue: undefined,
-  initialSuggestions: [],
-  onValueChange: undefined,
-  isFocused: false,
-  searchOnFocus: false,
 };

--- a/src/lib/forms/RichEditor.js
+++ b/src/lib/forms/RichEditor.js
@@ -293,14 +293,14 @@ export class RichEditor extends Component {
 
     const {
       id,
-      initialValue,
+      initialValue = "",
       disabled,
-      minHeight,
+      minHeight = 250,
       onBlur,
       onChange,
       onFocus,
       editorConfig,
-      inputValue,
+      inputValue = "",
       onEditorChange,
       files,
       onInit,
@@ -438,22 +438,4 @@ RichEditor.propTypes = {
   onFilesChange: PropTypes.func,
   onFileUpload: PropTypes.func,
   onFileDelete: PropTypes.func,
-};
-
-RichEditor.defaultProps = {
-  minHeight: 250,
-  initialValue: "",
-  inputValue: "",
-  id: undefined,
-  disabled: undefined,
-  onChange: undefined,
-  onEditorChange: undefined,
-  onBlur: undefined,
-  onFocus: undefined,
-  onInit: undefined,
-  editorConfig: undefined,
-  files: undefined,
-  onFilesChange: undefined,
-  onFileUpload: undefined,
-  onFileDelete: undefined,
 };

--- a/src/lib/forms/RichInputField.js
+++ b/src/lib/forms/RichInputField.js
@@ -17,13 +17,13 @@ export class RichInputField extends Component {
   renderFormField = (formikBag) => {
     const {
       fieldPath,
-      label,
-      required,
-      className,
+      label = "",
+      required = false,
+      className = "invenio-rich-input-field",
       editor,
       editorConfig,
-      disabled,
-      optimized,
+      disabled = false,
+      optimized = false,
     } = this.props;
     const value = getIn(formikBag.form.values, fieldPath, "");
     const initialValue = getIn(formikBag.form.initialValues, fieldPath, "");
@@ -67,7 +67,7 @@ export class RichInputField extends Component {
   };
 
   render() {
-    const { optimized, fieldPath, helpText } = this.props;
+    const { optimized = false, fieldPath, helpText } = this.props;
     const FormikField = optimized ? FastField : Field;
 
     return (
@@ -89,15 +89,4 @@ RichInputField.propTypes = {
   editorConfig: PropTypes.object,
   disabled: PropTypes.bool,
   helpText: PropTypes.string,
-};
-
-RichInputField.defaultProps = {
-  className: "invenio-rich-input-field",
-  optimized: false,
-  required: false,
-  label: "",
-  editor: undefined,
-  editorConfig: undefined,
-  disabled: false,
-  helpText: undefined,
 };

--- a/src/lib/forms/SelectField.js
+++ b/src/lib/forms/SelectField.js
@@ -66,17 +66,17 @@ export class SelectField extends Component {
       ...cmpProps
     } = formikProps;
     const {
-      defaultValue,
+      defaultValue = "",
       error,
       fieldPath,
-      label,
+      label = "",
       options,
       onChange,
       onAddItem,
-      multiple,
-      disabled,
-      required,
-      allowAdditions,
+      multiple = false,
+      disabled = false,
+      required = false,
+      allowAdditions = false,
       ...uiProps
     } = cmpProps;
 
@@ -163,7 +163,7 @@ export class SelectField extends Component {
   };
 
   render() {
-    const { optimized, fieldPath, helpText, ...uiProps } = this.props;
+    const { optimized = false, fieldPath, helpText, ...uiProps } = this.props;
     const FormikField = optimized ? FastField : Field;
     return (
       <>
@@ -193,18 +193,4 @@ SelectField.propTypes = {
   helpText: PropTypes.string,
   required: PropTypes.bool,
   disabled: PropTypes.bool,
-};
-
-SelectField.defaultProps = {
-  defaultValue: "",
-  optimized: false,
-  error: undefined,
-  label: "",
-  onChange: undefined,
-  onAddItem: undefined,
-  multiple: false,
-  helpText: undefined,
-  required: false,
-  disabled: false,
-  allowAdditions: false,
 };

--- a/src/lib/forms/TextAreaField.js
+++ b/src/lib/forms/TextAreaField.js
@@ -31,7 +31,7 @@ export class TextAreaField extends Component {
   };
 
   render() {
-    const { optimized, fieldPath, ...props } = this.props;
+    const { optimized = false, fieldPath, ...props } = this.props;
 
     const FormikField = optimized ? FastField : Field;
 
@@ -50,8 +50,4 @@ export class TextAreaField extends Component {
 TextAreaField.propTypes = {
   fieldPath: PropTypes.string.isRequired,
   optimized: PropTypes.bool,
-};
-
-TextAreaField.defaultProps = {
-  optimized: false,
 };

--- a/src/lib/forms/TextField.js
+++ b/src/lib/forms/TextField.js
@@ -17,11 +17,11 @@ export class TextField extends Component {
     const {
       fieldPath,
       error,
-      helpText,
-      disabled,
+      helpText = "",
+      disabled = false,
       label,
-      optimized,
-      required,
+      optimized = false,
+      required = false,
       ...uiProps
     } = this.props;
     const FormikField = optimized ? FastField : Field;
@@ -87,12 +87,4 @@ TextField.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   optimized: PropTypes.bool,
   required: PropTypes.bool,
-};
-
-TextField.defaultProps = {
-  error: undefined,
-  helpText: "",
-  disabled: false,
-  optimized: false,
-  required: false,
 };

--- a/src/lib/forms/ToggleField.js
+++ b/src/lib/forms/ToggleField.js
@@ -23,8 +23,16 @@ export class ToggleField extends Component {
      * formikProps: current Formik props (ToggleField instance)
      */
 
-    const { onValue, offValue, onLabel, offLabel, fieldPath, onChange, ...uiProps } =
-      this.props;
+    const {
+      onValue,
+      offValue,
+      onLabel,
+      offLabel,
+      fieldPath,
+      onChange,
+      optimized = true,
+      ...uiProps
+    } = this.props;
 
     const isChecked = getIn(formikProps.form.values, fieldPath) === onValue;
     const handleChange = () => {
@@ -54,7 +62,7 @@ export class ToggleField extends Component {
   };
 
   render() {
-    const { optimized, fieldPath } = this.props;
+    const { optimized = true, fieldPath } = this.props;
     const FormikField = optimized ? FastField : Field;
     return <FormikField name={fieldPath} component={this.renderFormField} />;
   }
@@ -68,9 +76,4 @@ ToggleField.propTypes = {
   fieldPath: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   optimized: PropTypes.bool,
-};
-
-ToggleField.defaultProps = {
-  onChange: undefined,
-  optimized: true,
 };

--- a/src/lib/forms/fieldComponents.js
+++ b/src/lib/forms/fieldComponents.js
@@ -49,7 +49,6 @@ const showHideComponent = (Component, id) => {
     Component.displayName || Component.name
   })`;
   ShowHideComponent.propTypes = { ...Component.propTypes };
-  ShowHideComponent.defaultProps = { ...Component.defaultProps };
   return ShowHideComponent;
 };
 
@@ -85,7 +84,6 @@ export const showHideOverridableWithDynamicId = (Widget) => {
   };
 
   Component.propTypes = { ...Widget.propTypes, id: PropTypes.string };
-  Component.defaultProps = { ...Widget.defaultProps, id: undefined };
   Component.displayName = `DynamicOverridable(${Widget.displayName || Widget.name})`;
   return Component;
 };

--- a/src/lib/forms/widgets/array/Array.js
+++ b/src/lib/forms/widgets/array/Array.js
@@ -19,7 +19,7 @@ class ArrayComponent extends Component {
       children,
       addButtonLabel,
       defaultNewValue,
-      className,
+      className = "",
       helpText: helpTextProp,
       labelIcon: labelIconProp,
     } = this.props;
@@ -59,11 +59,6 @@ ArrayComponent.propTypes = {
    */
   description: PropTypes.string.isRequired,
   ...fieldCommonProps,
-};
-
-ArrayComponent.defaultProps = {
-  className: "",
-  icon: undefined,
 };
 
 export const Array = showHideOverridableWithDynamicId(ArrayComponent);

--- a/src/lib/forms/widgets/custom_fields/AddDiscoverableFieldsModal.js
+++ b/src/lib/forms/widgets/custom_fields/AddDiscoverableFieldsModal.js
@@ -183,9 +183,3 @@ AddDiscoverableFieldsModal.propTypes = {
   sections: PropTypes.array,
   existingFields: PropTypes.array.isRequired,
 };
-
-AddDiscoverableFieldsModal.defaultProps = {
-  icon: undefined,
-  label: undefined,
-  sections: undefined,
-};

--- a/src/lib/forms/widgets/custom_fields/CustomFields.js
+++ b/src/lib/forms/widgets/custom_fields/CustomFields.js
@@ -23,7 +23,10 @@ export class CustomFields extends Component {
   }
 
   populateConfig = async () => {
-    const { includesPaths, fieldPathPrefix } = this.props;
+    const {
+      includesPaths = (fields) => fields.map((field) => field.key),
+      fieldPathPrefix,
+    } = this.props;
     try {
       const { sectionsConfig, discoverFieldsConfig } =
         await this.loadCustomFieldsWidgets();
@@ -96,7 +99,7 @@ export class CustomFields extends Component {
 
   render() {
     const { sections, discoverFieldsSections } = this.state;
-    const { templateLoaders, record, severityChecks } = this.props;
+    const { templateLoaders, record, severityChecks = null } = this.props;
 
     return (
       <>
@@ -159,9 +162,4 @@ CustomFields.propTypes = {
   includesPaths: PropTypes.func,
   severityChecks: PropTypes.object,
   record: PropTypes.object.isRequired,
-};
-
-CustomFields.defaultProps = {
-  includesPaths: (fields) => fields.map((field) => field.key),
-  severityChecks: null,
 };

--- a/src/lib/forms/widgets/custom_fields/DiscoverFieldsSection.js
+++ b/src/lib/forms/widgets/custom_fields/DiscoverFieldsSection.js
@@ -98,7 +98,11 @@ class DiscoverFieldsSection extends Component {
   };
 
   render() {
-    const { templateLoaders, record, discoverSectionLabel } = this.props;
+    const {
+      templateLoaders,
+      record,
+      discoverSectionLabel = "Domain specific fields",
+    } = this.props;
     const { sections, tempFields, recordFields } = this.state;
     const existingFields = [
       ...Object.entries(tempFields).map(([key, value]) => value.key),
@@ -151,10 +155,6 @@ DiscoverFieldsSection.propTypes = {
   sections: PropTypes.array.isRequired,
   record: PropTypes.object.isRequired,
   discoverSectionLabel: PropTypes.string,
-};
-
-DiscoverFieldsSection.defaultProps = {
-  discoverSectionLabel: "Domain specific fields",
 };
 
 export default Overridable.component(

--- a/src/lib/forms/widgets/custom_fields/ListAndFilterCustomFields.js
+++ b/src/lib/forms/widgets/custom_fields/ListAndFilterCustomFields.js
@@ -159,7 +159,3 @@ ListAndFilterCustomFields.propTypes = {
   handleSelectField: PropTypes.func.isRequired,
   sections: PropTypes.array,
 };
-
-ListAndFilterCustomFields.defaultProps = {
-  sections: undefined,
-};

--- a/src/lib/forms/widgets/custom_fields/SubjectAutocompleteDropdown.js
+++ b/src/lib/forms/widgets/custom_fields/SubjectAutocompleteDropdown.js
@@ -18,7 +18,7 @@ export class SubjectAutocompleteDropdown extends Component {
     });
 
   prepareSuggest = (searchQuery) => {
-    const { limitTo } = this.props;
+    const { limitTo = "" } = this.props;
     return limitTo === "" || limitTo === "all"
       ? searchQuery
       : `${limitTo}:${searchQuery}`;
@@ -27,16 +27,16 @@ export class SubjectAutocompleteDropdown extends Component {
   render() {
     const {
       fieldPath,
-      required,
-      multiple,
-      placeholder,
-      clearable,
-      label,
+      required = false,
+      multiple = true,
+      placeholder = "Search for a subject by name",
+      clearable = true,
+      label = "",
       icon,
       width,
-      allowAdditions,
-      noQueryMessage,
-      disabled,
+      allowAdditions = true,
+      noQueryMessage = "Search or create subjects...",
+      disabled = false,
       ...uiProps
     } = this.props;
     const labelContent = label ? (
@@ -109,18 +109,4 @@ SubjectAutocompleteDropdown.propTypes = {
   allowAdditions: PropTypes.bool,
   noQueryMessage: PropTypes.string,
   disabled: PropTypes.bool,
-};
-
-SubjectAutocompleteDropdown.defaultProps = {
-  required: false,
-  limitTo: "",
-  label: "",
-  icon: undefined,
-  multiple: true,
-  clearable: true,
-  placeholder: "Search for a subject by name",
-  width: undefined,
-  noQueryMessage: "Search or create subjects...",
-  allowAdditions: true,
-  disabled: false,
 };

--- a/src/lib/forms/widgets/loader.js
+++ b/src/lib/forms/widgets/loader.js
@@ -12,7 +12,7 @@ export async function importWidget(
   { ui_widget: UIWidget, fieldPath, record, props },
   createElement = true
 ) {
-  let component = undefined;
+  let component;
   // Try import widget from user's defined templateLoaders
   for (const loader of templateLoaders) {
     try {

--- a/src/lib/forms/widgets/select/AutocompleteDropdown.js
+++ b/src/lib/forms/widgets/select/AutocompleteDropdown.js
@@ -19,11 +19,11 @@ class AutocompleteDropdownComponent extends Component {
       required,
       label,
       icon,
-      clearable,
+      clearable = false,
       placeholder,
-      multiple,
+      multiple = false,
       autocompleteFrom,
-      autocompleteFromAcceptHeader,
+      autocompleteFromAcceptHeader = "application/vnd.inveniordm.v1+json",
       helpText: helpTextProp,
       labelIcon: labelIconProp,
       disabled,
@@ -93,14 +93,6 @@ AutocompleteDropdownComponent.propTypes = {
    */
   icon: PropTypes.string,
   ...fieldCommonProps,
-};
-
-AutocompleteDropdownComponent.defaultProps = {
-  autocompleteFromAcceptHeader: "application/vnd.inveniordm.v1+json",
-  clearable: false,
-  multiple: false,
-  icon: undefined,
-  description: undefined,
 };
 
 export const AutocompleteDropdown = showHideOverridableWithDynamicId(

--- a/src/lib/forms/widgets/select/Dropdown.js
+++ b/src/lib/forms/widgets/select/Dropdown.js
@@ -25,13 +25,13 @@ class DropdownComponent extends Component {
       icon,
       labelIcon: labelIconProp,
       options,
-      search,
-      multiple,
-      clearable,
+      search = false,
+      multiple = false,
+      clearable = true,
       required,
       disabled,
-      optimized,
-      allowAdditions,
+      optimized = true,
+      allowAdditions = false,
     } = this.props;
 
     const helpText = helpTextProp ?? description;
@@ -82,16 +82,6 @@ DropdownComponent.propTypes = {
   optimized: PropTypes.bool,
   allowAdditions: PropTypes.bool,
   ...fieldCommonProps,
-};
-
-DropdownComponent.defaultProps = {
-  icon: undefined,
-  search: false,
-  multiple: false,
-  clearable: true,
-  description: undefined,
-  optimized: true,
-  allowAdditions: false,
 };
 
 export const Dropdown = showHideOverridableWithDynamicId(DropdownComponent);

--- a/src/lib/forms/widgets/text/BooleanCheckbox.js
+++ b/src/lib/forms/widgets/text/BooleanCheckbox.js
@@ -27,7 +27,7 @@ function BooleanCheckboxComponent({
   required,
   helpText: helpTextProp,
   labelIcon: labelIconProp,
-  optimized,
+  optimized = true,
 }) {
   const helpText = helpTextProp ?? description;
   const labelIcon = labelIconProp ?? icon;
@@ -80,11 +80,6 @@ BooleanCheckboxComponent.propTypes = {
   icon: PropTypes.string,
   optimized: PropTypes.bool,
   ...fieldCommonProps,
-};
-
-BooleanCheckboxComponent.defaultProps = {
-  icon: undefined,
-  optimized: true,
 };
 
 export const BooleanCheckbox = showHideOverridableWithDynamicId(

--- a/src/lib/forms/widgets/text/Input.js
+++ b/src/lib/forms/widgets/text/Input.js
@@ -17,7 +17,7 @@ export class InputComponent extends Component {
       placeholder,
       description,
       disabled,
-      type,
+      type = "input",
       helpText: helpTextProp,
       labelIcon: labelIconProp,
     } = this.props;
@@ -51,12 +51,6 @@ InputComponent.propTypes = {
   icon: PropTypes.string,
   type: PropTypes.string,
   ...fieldCommonProps,
-};
-
-InputComponent.defaultProps = {
-  icon: undefined,
-  description: undefined,
-  type: "input",
 };
 
 export const Input = showHideOverridableWithDynamicId(InputComponent);

--- a/src/lib/forms/widgets/text/MultiInput.js
+++ b/src/lib/forms/widgets/text/MultiInput.js
@@ -19,7 +19,7 @@ function MultiInputComponent({
   disabled,
   helpText: helpTextProp,
   labelIcon: labelIconProp,
-  optimized,
+  optimized = true,
   ...uiProps
 }) {
   const [options, setOptions] = useState([]);
@@ -78,12 +78,6 @@ MultiInputComponent.propTypes = {
   icon: PropTypes.string,
   optimized: PropTypes.bool,
   ...fieldCommonProps,
-};
-
-MultiInputComponent.defaultProps = {
-  additionLabel: undefined,
-  icon: undefined,
-  optimized: true,
 };
 
 export const MultiInput = showHideOverridableWithDynamicId(MultiInputComponent);

--- a/src/lib/forms/widgets/text/RichInput.js
+++ b/src/lib/forms/widgets/text/RichInput.js
@@ -15,11 +15,11 @@ class RichInputComponent extends Component {
       label,
       icon,
       description,
-      editorConfig,
+      editorConfig = {},
       disabled,
       helpText: helpTextProp,
       labelIcon: labelIconProp,
-      optimized,
+      optimized = true,
     } = this.props;
 
     const helpText = helpTextProp ?? description;
@@ -54,12 +54,6 @@ RichInputComponent.propTypes = {
   description: PropTypes.string.isRequired,
   optimized: PropTypes.bool,
   ...fieldCommonProps,
-};
-
-RichInputComponent.defaultProps = {
-  icon: undefined,
-  editorConfig: {},
-  optimized: true,
 };
 
 export const RichInput = showHideOverridableWithDynamicId(RichInputComponent);

--- a/src/lib/forms/widgets/text/TextArea.js
+++ b/src/lib/forms/widgets/text/TextArea.js
@@ -15,7 +15,7 @@ class TextAreaComponent extends Component {
       label,
       icon,
       description,
-      rows,
+      rows = 3,
       disabled,
       helpText: helpTextProp,
       labelIcon: labelIconProp,
@@ -51,11 +51,6 @@ TextAreaComponent.propTypes = {
    */
   description: PropTypes.string.isRequired,
   ...fieldCommonProps,
-};
-
-TextAreaComponent.defaultProps = {
-  icon: undefined,
-  rows: 3,
 };
 
 export const TextArea = showHideOverridableWithDynamicId(TextAreaComponent);


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

- Replaces `defaultProps` with ES6 default parameter syntax across all function and pure class (render-only) components.
- React 18 deprecates `defaultProps` on function components and produces (lots of) deprecation warnings; class component `defaultProps` are intentionally preserved. See here: https://github.com/facebook/react/blob/main/CHANGELOG.md#1830-april-25-2024

Requires:
- https://github.com/inveniosoftware/react-invenio-forms/pull/334

Part of: inveniosoftware/rfcs#112

### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.