### PR TITLE
forms: disabled advanced cell properties in editor table

### DIFF
--- a/src/lib/forms/RichEditor.js
+++ b/src/lib/forms/RichEditor.js
@@ -331,6 +331,7 @@ export class RichEditor extends Component {
       autoresize_bottom_margin: 20,
       block_formats: "Paragraph=p; Header 1=h1; Header 2=h2; Header 3=h3",
       table_advtab: false,
+      table_cell_advtab: false,
       convert_urls: false,
       setup: (editor) => {
         this.registerCustomPreviewButton(editor);


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes Issue https://github.com/zenodo/ops/issues/529
**Before**
<img width="463" height="458" alt="Screenshot 2026-05-21 at 11 23 49" src="https://github.com/user-attachments/assets/3a4b0512-c313-41e4-aece-99175f1f2779" />

**After**
<img width="468" height="312" alt="Screenshot 2026-05-21 at 11 23 13" src="https://github.com/user-attachments/assets/4a860f95-de2f-4d8d-a331-2f43f2a5b07a" />


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
