### PR TITLE
fix(forms): render severity feedback

### DIFF
--- a/src/lib/forms/ErrorLabel.js
+++ b/src/lib/forms/ErrorLabel.js
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2020 CERN.
  * SPDX-FileCopyrightText: 2020 Northwestern University.
+ * SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
  * SPDX-License-Identifier: MIT
  */
 
@@ -9,11 +10,15 @@ import _get from "lodash/get";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Label } from "semantic-ui-react";
+import { FeedbackLabel } from "./FeedbackLabel";
 
 export class ErrorLabel extends Component {
   renderFormField = ({ form: { errors, initialErrors } }) => {
     const { fieldPath, ...uiProps } = this.props;
     const error = _get(errors, fieldPath, "") || _get(initialErrors, fieldPath, "");
+    if (typeof error === "object" && error?.message && error?.severity) {
+      return <FeedbackLabel fieldPath={fieldPath} injectedError={error} {...uiProps} />;
+    }
     return error ? <Label pointing prompt content={error} {...uiProps} /> : null;
   };
 


### PR DESCRIPTION


:heart: Thank you for your contribution!

### Description

* This change keeps curation feedback translated and structured end to end. The backend now guarantees that translated rule text is serialized as strings, while preserving severity metadata.

* The frontend shared error label now understands that structured feedback shape, so generic deposit fields can show warnings and info messages without treating them as plain errors or crashing on object values.

* related: https://github.com/inveniosoftware/invenio-app-rdm/issues/3499

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
